### PR TITLE
Improvements to MacOS build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "multibuild"]
+	path = multibuild
+	url = https://github.com/matthew-brett/multibuild.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,3 @@ deploy:
   skip_cleanup: true
   on:
     repo: tlecomte/friture
-    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,19 @@
-language: objective-c
 os: osx
-python:
-  - '3.6'
+language: generic
+env:
+  - MB_PYTHON_VERSION=3.6
 before_install:
-  - echo $MACOSX_DEPLOYMENT_TARGET
-  - brew update
-  - brew install python3
+  - source multibuild/common_utils.sh
+  - source multibuild/travis_steps.sh
+  - before_install
   - which python3
-  - python3 --version
+  - python3 -c 'import sys; print(sys.version)'
+  - brew update
   - brew install qt5 # this is needed to get macdeployqt, which is not in the PyPI PyQt5 wheel
 install:
-  - pip3 install --upgrade --user setuptools
-  - pip3 install --upgrade wheel
   - pip3 install -r requirements.txt
-  - pip3 install -U py2app
+  - pip3 install -U "py2app==0.14"
 script:
-  - python3 setup.py build_ext --inplace
-  - sed -i '.bak' -e 's/file(p/open(p/g' /usr/local/lib/python3.*/site-packages/py2app/recipes/pyopengl.py
-  - sed -i '.bak' -e 's/loader=loader.filename)/loader_path=loader.filename)/g' /usr/local/lib/python3.*/site-packages/macholib/MachOGraph.py
   - python3 setup.py py2app
   - "/usr/local/opt/qt5/bin/macdeployqt dist/friture.app -dmg"
   - du -hs dist/friture.app

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ install:
   - pip3 install -r requirements.txt
   - pip3 install -U "py2app==0.14"
 script:
+  - python3 setup.py build_ext --inplace
   - python3 setup.py py2app
   - "/usr/local/opt/qt5/bin/macdeployqt ../friture-dist/friture.app -dmg"
   - du -hs ../friture-dist/friture.app

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,18 +15,18 @@ install:
   - pip3 install -U "py2app==0.14"
 script:
   - python3 setup.py py2app
-  - "/usr/local/opt/qt5/bin/macdeployqt dist/friture.app -dmg"
-  - du -hs dist/friture.app
-  - du -hs dist/friture.dmg
+  - "/usr/local/opt/qt5/bin/macdeployqt ../friture-dist/friture.app -dmg"
+  - du -hs ../friture-dist/friture.app
+  - du -hs ../friture-dist/friture.dmg
   - export DMG_FILENAME=friture-$(python3 -c 'import friture; print(friture.__version__)')-$(date +'%Y%m%d').dmg
   - echo $DMG_FILENAME
-  - mv dist/friture.dmg dist/$DMG_FILENAME
+  - mv ../friture-dist/friture.dmg ../friture-dist/$DMG_FILENAME
 deploy:
   provider: releases
   draft: true
   api_key:
     secure: N19tf9SJmo3KluUL3DjGMxTTGaa9/qu6UNxqPtOyRu/StSzU1yeh1D8oZr+qYl6tWeqogvSWKlDw78Dp1c4Ro0IQB7ebgxT4YJGF6DeuCo1gvi1uE84Xh+Hl+Y4urS52F3ABSAHejhYhJW7XxsrA3MCiz56S7OEsuDp1u4fG8LM=
-  file: dist/$DMG_FILENAME
+  file: ../friture-dist/$DMG_FILENAME
   skip_cleanup: true
   on:
     repo: tlecomte/friture

--- a/config.sh
+++ b/config.sh
@@ -1,0 +1,15 @@
+# Define custom utilities for multibuild
+# Test for OSX with [ -n "$IS_OSX" ]
+
+function pre_build {
+    # Any stuff that you need to do before you start building the wheels
+    # Runs in the root directory of this repository.
+    :
+}
+
+function run_tests {
+    # Runs tests on installed distribution from an empty directory
+    # python --version
+    # python -c 'import sys; import yourpackage; sys.exit(yourpackage.test())'
+    :
+}

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ from glob import glob
 import os
 from os.path import join, dirname  # for README content reading and py2exe fix
 import os.path
+from pathlib import Path
 import numpy
 import friture  # for the version number
 import sounddevice # to find the libportaudio.dylib path
@@ -134,9 +135,14 @@ elif py2app_build:
     base = os.path.dirname(sounddevice.__file__)
     libportaudio_path = os.path.join(base, "_sounddevice_data", "portaudio-binaries", "libportaudio.dylib")
 
+    # prevent a py2app self-referencing loop by moving the bdist and dist folders out of the current directory
+    # see https://stackoverflow.com/questions/7701255/py2app-ioerror-errno-63-file-name-too-long
+    parent_dir = str(Path(os.getcwd()).parent)
     py2app_options = {'includes': includes,
                       'iconfile': 'resources/images/friture.icns',
-                      'frameworks': [libportaudio_path]}
+                      'frameworks': [libportaudio_path],
+                      'bdist_base': os.path.join(parent_dir, 'friture-build'),
+                      'dist_dir': os.path.join(parent_dir, 'friture-dist')}
 
     extra_options = dict(
         setup_requires=['py2app'],


### PR DESCRIPTION
Use a MacPython distribution of Python to get MacOS 10.6+ compatibility.
Deploy even when there is no tag.
Remove old workarounds.