### PR TITLE
Use a recent pyinstaller (unreleased)

### DIFF
--- a/installer/friture-setup.nsi
+++ b/installer/friture-setup.nsi
@@ -107,8 +107,8 @@ Section "MainSection" SEC01
   SetOutPath "$INSTDIR\_sounddevice_data"
   File /r "${PROJECT_PATH}\dist\friture\_sounddevice_data\*"
 
-  SetOutPath "$INSTDIR\qt5_plugins"
-  File /r "${PROJECT_PATH}\dist\friture\qt5_plugins\*"
+  SetOutPath "$INSTDIR\PyQt5"
+  File /r "${PROJECT_PATH}\dist\friture\PyQt5\*"
 
   SetOutPath "$INSTDIR"
   File "${PROJECT_PATH}\dist\friture\base_library.zip"

--- a/winbuild.ps1
+++ b/winbuild.ps1
@@ -101,8 +101,8 @@ Write-Host "==========================================="
 # install a version of pefile that does not use the past library, which in turn imports too many things
 & pip install git+https://github.com/tlecomte/pefile.git@tlecomte-remove-past
 
-# install our fork of pyinstaller that lets python35.dll be signed
-& pip install -U git+https://github.com/tlecomte/pyinstaller.git@tlecomte-sign
+# install a recent pyinstaller with no need for mscvr*.dll, and that lets python35.dll be signed
+& pip install -U git+https://github.com/pyinstaller/pyinstaller.git@469f1fa19275e415110f783fd538ad46805edff4
 
 Write-Host ""
 Write-Host "==========================================="


### PR DESCRIPTION
This version is supposed to have no msvcr*.dll dependency and it should also not corrupt python35.dll signature