### PR TITLE
Appveyor artifacts: add a zip archive of pyinstaller output

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,6 +26,8 @@ artifacts:
     name: xref-friture
   - path: build/friture/graph-friture.dot
     name: graph-friture
+  - path: dist/friture.zip
+    name: friture
 deploy:
   provider: GitHub
   auth_token:

--- a/winbuild.ps1
+++ b/winbuild.ps1
@@ -120,6 +120,12 @@ Write-Host "==========================================="
 
 Write-Host ""
 Write-Host "==========================================="
+Write-Host "Archiving the package as a zip file"
+Write-Host "==========================================="
+Compress-Archive -Path .\dist\friture\* -DestinationPath .\dist\friture.zip
+
+Write-Host ""
+Write-Host "==========================================="
 Write-Host "Building the NSIS installer"
 Write-Host "==========================================="
 


### PR DESCRIPTION
To package Friture for Windows using DesktopAppConverter, the input is the output of pyinstaller. Here we add this output as a zip file. Previously only the NSIS installer was published as an artifact. This will make it easier to publish the new versions to the Windows store.