### PR TITLE
Fix pip install, now properly installs dependencies

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -9,6 +9,14 @@ before_install
 which python3
 python3 -c 'import sys; print(sys.version)'
 
+if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
+    # workaround for https://github.com/pypa/packaging-problems/issues/134
+    # build-time dependencies define in `setup_requires` are resolved
+    # on macOS Python with TLSv1, which is now disabled, so that fails
+    pip3 install numpy==1.13.3
+    pip3 install Cython==0.27.3
+fi
+
 pip3 install -r requirements.txt
 
 # py2app and pysinstaller need to have the extensions built explicitely

--- a/friture/__init__.py
+++ b/friture/__init__.py
@@ -18,10 +18,10 @@
 # along with Friture.  If not, see <http://www.gnu.org/licenses/>.
 
 # version and date
-__version__ = "0.37"
+__version__ = "0.38"
 # NSIS (because of Windows) requires the version to be in the format X.X.X.X
 # the following line is read by the installer
-__versionXXXX__ = "0.37.0.0"
-__releasedate__ = "2019-02-15"
+__versionXXXX__ = "0.38.0.0"
+__releasedate__ = "2019-02-17"
 
 __all__ = ["plotting"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,3 @@
-Cython==0.27.3
-sounddevice==0.3.10
-PyOpenGL==3.1.0
-PyOpenGL-accelerate==3.1.0
-docutils==0.14
-numpy==1.13.3
-PyQt5==5.10.1
-appdirs==1.4.3
-pyrr==0.9.2
+# dependencies are taken from 'install_requires' in setup.py
+# reference: https://caremad.io/posts/2013/07/setup-vs-requirement/
+-e .

--- a/scripts/friture
+++ b/scripts/friture
@@ -2,7 +2,8 @@
 import sys
 
 # allow this script to be executed as a child of another script (lsprofcalltree, for example)
-sys.path.insert(0, '.')
+# (add at the end to favor system-installed packages)
+sys.path.append('.')
 
 from friture.analyzer import main
 

--- a/setup.py
+++ b/setup.py
@@ -144,7 +144,6 @@ elif py2app_build:
                       'dist_dir': dist_dir}
 
     extra_options = dict(
-        setup_requires=['py2app'],
         app=['main.py'],
         options={'py2app': py2app_options},
     )
@@ -194,6 +193,9 @@ install_requires = [
 
 # Cython and numpy are needed when running setup.py, to build extensions
 setup_requires=["numpy==1.13.3", "Cython==0.27.3"]
+
+if py2app_build:
+    setup_requires.append("py2app")
 
 setup(name="friture",
       version=friture.__version__,


### PR DESCRIPTION
This addresses #99 by fixing how dependencies are retrieved by `python setup.py install`, and consequently by `pip install friture`.

With these fixes, the above commands will first install Cython and Numpy (since they are needed to build the extensions), then install Friture itself, then install all of its dependencies (Numpy again, PyOpenGL, PyQt5, etc.).

Tested in Ubuntu 14.04.