### PR TITLE
Upgrade numpy to 1.16.1

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -13,7 +13,7 @@ if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
     # workaround for https://github.com/pypa/packaging-problems/issues/134
     # build-time dependencies define in `setup_requires` are resolved
     # on macOS Python with TLSv1, which is now disabled, so that fails
-    pip3 install numpy==1.13.3
+    pip3 install numpy==1.16.2
     pip3 install Cython==0.27.3
 fi
 

--- a/setup.py
+++ b/setup.py
@@ -185,14 +185,14 @@ install_requires = [
     "PyOpenGL==3.1.0",
     "PyOpenGL-accelerate==3.1.0",
     "docutils==0.14",
-    "numpy==1.13.3",
+    "numpy==1.16.2",
     "PyQt5==5.10.1",
     "appdirs==1.4.3",
     "pyrr==0.9.2",
 ]
 
 # Cython and numpy are needed when running setup.py, to build extensions
-setup_requires=["numpy==1.13.3", "Cython==0.27.3"]
+setup_requires=["numpy==1.16.2", "Cython==0.27.3"]
 
 if py2app_build:
     setup_requires.append("py2app")


### PR DESCRIPTION
This aims at solving a numpy incompatibility with AppImages built on Travis. There seems to be an incompatibility between the Travis system Python (1.15) and the one we were requiring (1.13.3), resulting in runtime fatal errors.