### PR TITLE
(Travis Linux) Build with Ubuntu 16.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 matrix:
   include:
   - os: linux
-    dist: trusty # use Ubuntu 14.04 LTS for maximum backward compatibility of the AppImage
+    dist: xenial # use Ubuntu 16.04 LTS will be the minimum required version for the AppImage
     language: python
     python: "3.5" # pin for Linux builds (on macos, the multibuild python is used instead)
   - os: osx

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -35,7 +35,7 @@ if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
 else
     # Linux
     sudo apt-get update
-    sudo apt-get install -y libportaudio0
+    sudo apt-get install -y libportaudio2
     sudo apt-get install -y desktop-file-utils # for desktop-file-validate, used by pkg2appimage
 
     # about pep517, see https://github.com/pypa/pip/issues/6163

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,7 +10,7 @@ The following steps can be used to prepare a development environment for Friture
 
 Prerequisite: a 64 bits Linux installation (PyQt5 wheels for Linux are only available for 64 bits).
 
-This has been tested in a Virtualbox image for Ubuntu Trusty 14.04 LTS 64 bits from osboxes.org. The following custom settings have been set on the VM: increase video memory, enable 3d acceleration, enable audio input, install guest addition, add user to vboxsf (for file sharing with the host), keyboard layout setup.
+This has been tested in a Virtualbox image for Ubuntu Trusty 16.04 LTS 64 bits from osboxes.org. The following custom settings have been set on the VM: increase video memory, enable 3d acceleration, enable audio input, install guest addition, add user to vboxsf (for file sharing with the host), keyboard layout setup.
 
 1. Install git
 ```
@@ -20,7 +20,7 @@ sudo apt-get install -y git
 
 2. Install `portaudio` (used for audio IO in Friture)
 ```
-sudo apt-get install -y libportaudio0
+sudo apt-get install -y libportaudio2
 ```
 
 3. Install python 3.5 and related build tools (appropriate PyQt5 wheels for Linux are only available for Python 3.5+)

--- a/appimage/friture.yml
+++ b/appimage/friture.yml
@@ -4,7 +4,7 @@
 app: friture
 
 ingredients:
-  dist: trusty
+  dist: xenial
   sources: []
   packages: []
 


### PR DESCRIPTION
Friture AppImage is built so far with Ubuntu 14.04 LTS. The next LTS of Ubuntu is 16.04, which is already 6 years old. We can surely upgrade safely to that version as the minimum required version to run Friture.