### PR TITLE
use full decimation instead of fast

### DIFF
--- a/friture/audioproc.py
+++ b/friture/audioproc.py
@@ -43,9 +43,6 @@ class audioproc():
     def analyzelive(self, samples):
         samples = self.decimate(samples)
 
-        # uncomment the following to disable the decimation altogether
-        # decimation = 1
-
         # FFT for a linear transformation in frequency scale
         fft = rfft(samples * self.window)
         spectrum = self.norm_square(fft)
@@ -60,9 +57,9 @@ class audioproc():
         if self.decimation > 1:
             samples.shape = len(samples) // self.decimation, self.decimation
             # the full way
-            # samples = samples.mean(axis=1)
-            # the simplest way
-            samples = samples[:, 0]
+            samples = samples.mean(axis=1)
+            # the fastest way
+            # samples = samples[:, 0]
         return samples
 
     def set_fftsize(self, fft_size):


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/28263393/72959099-49654e80-3d77-11ea-902a-69b4e142abd1.png)
_Figure 1. Top-right: the fast decimation function. Bottom-left: the slow decimation function. Note the prominence of the artifacts generated by higher harmonics._

### TL;DR
This PR switches the decimation function from the fast version to the slower, better version. 

### Costs and Benefits
The benefit of this is that a plotted spectrum is more accurate (though still not perfectly) in the presence of frequencies higher than the maximum frequency in the view, such as harmonics.

The cost of this is that it makes the decimation function take almost as much time as the FFT function (93%) instead of much less (7%). (caveat: I don't know if the FFT is actually the proper thing to compare it to, it was just convenient)

I think this is worth it, because both the cost and benefit present themselves only when decimation is used, and I think the prominent artifacts are worse than it being a little more cpu intensive.

### Other Notes
For background, including how to reproduce the issue described here, see https://github.com/tlecomte/friture/issues/132

There also might be a better way to eliminate/reduce these artifacts; I'm not a sound engineer and I haven't done a lot of research on this topic.

(This change will also affect the FFT spectrum view, in addition to the 2D spectrogram view, but that seemed like it would be harder to demonstrate visually)