### PR TITLE
Fix changes about deprecation of float index in linespace (#127)

### DIFF
--- a/friture/audioproc.py
+++ b/friture/audioproc.py
@@ -105,7 +105,7 @@ class audioproc():
     def update_freq_cache(self):
         if len(self.freq) != self.fft_size / (2 * self.decimation) + 1:
             self.logger.info("audioproc: updating self.freq cache")
-            self.freq = linspace(0, SAMPLING_RATE / (2 * self.decimation), self.fft_size / (2 * self.decimation) + 1)
+            self.freq = linspace(0, SAMPLING_RATE / (2 * self.decimation), int(self.fft_size / (2 * self.decimation) + 1))
 
             # compute psychoacoustic weighting. See http://en.wikipedia.org/wiki/A-weighting
             f = self.freq


### PR DESCRIPTION
This close issue #127, caused by some changes to numpy (numpy/numpy@f4dfe83).
 Fix it's provided by @DoMiNeLa10