### PR TITLE
Use floor division to get integer values

### DIFF
--- a/friture/audioproc.py
+++ b/friture/audioproc.py
@@ -106,7 +106,7 @@ class audioproc():
     def update_freq_cache(self):
         if len(self.freq) != self.fft_size / (2 * self.decimation) + 1:
             self.logger.info("audioproc: updating self.freq cache")
-            self.freq = linspace(0, SAMPLING_RATE / (2 * self.decimation), self.fft_size / (2 * self.decimation) + 1)
+            self.freq = linspace(0, SAMPLING_RATE // (2 * self.decimation), self.fft_size // (2 * self.decimation) + 1)
 
             # compute psychoacoustic weighting. See http://en.wikipedia.org/wiki/A-weighting
             f = self.freq


### PR DESCRIPTION
Somehow I wasn't able to start friture anymore. I'm not sure what changed since it last worked, i don't use friture that regularly.

I am not sure whats going on exactly. Although the [linspace-documention](https://docs.scipy.org/doc/numpy/reference/generated/numpy.linspace.html) mentions integers, there are actually floats (2.0, is this a float in python?) in the examples.

Anyway, fixing the division (which returns a float) to a floor division (which returns an int) fixed the issue for me.

I'm on manjaro using [friture-git](https://aur.archlinux.org/packages/friture-git/)

```
~ >>> friture                                                                                                                        
2020-02-01 22:41:53,022 INFO friture.analyzer: Friture 0.41 starting on Linux (linux)
2020-02-01 22:41:53,041 DEBUG friture.analyzer: using qt5ct plugin
2020-02-01 22:41:53,113 INFO friture.audiobackend: Initializing audio backend
2020-02-01 22:41:53,113 INFO friture.audiobackend: Opening the stream for device 'pulse'
2020-02-01 22:41:53,117 INFO friture.audiobackend: Device claims 42 ms latency
2020-02-01 22:41:53,118 INFO friture.audiobackend: Success
2020-02-01 22:41:53,147 INFO friture.octavespectrum_settings: bandsperoctavechanged slot 2 6
2020-02-01 22:41:53,150 INFO friture.octavespectrum_settings: responsetimechanged slot 1 0
2020-02-01 22:41:53,153 INFO friture.audioproc: audioproc: updating self.freq cache
2020-02-01 22:41:53,154 CRITICAL friture.exceptionhandler: Unhandled exception: Traceback (most recent call last):
  File "/usr/lib/python3.8/site-packages/numpy/core/function_base.py", line 117, in linspace
    num = operator.index(num)
TypeError: 'float' object cannot be interpreted as an integer

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/friture", line 10, in <module>
    main()
  File "/usr/lib/python3.8/site-packages/friture/analyzer.py", line 365, in main
    window = Friture()
  File "/usr/lib/python3.8/site-packages/friture/analyzer.py", line 115, in __init__
    self.restoreAppState()
  File "/usr/lib/python3.8/site-packages/friture/analyzer.py", line 217, in restoreAppState
    self.dockmanager.restoreState(settings)
  File "/usr/lib/python3.8/site-packages/friture/dockmanager.py", line 77, in restoreState
    dock.restoreState(settings)
  File "/usr/lib/python3.8/site-packages/friture/dock.py", line 109, in restoreState
    self.widget_select(widgetId)
  File "/usr/lib/python3.8/site-packages/friture/dock.py", line 76, in widget_select
    self.audiowidget = getWidgetById(widgetId)["Class"](self)
  File "/usr/lib/python3.8/site-packages/friture/spectrum.py", line 57, in __init__
    self.proc.set_maxfreq(self.maxfreq)
  File "/usr/lib/python3.8/site-packages/friture/audioproc.py", line 84, in set_maxfreq
    self.update_freq_cache()
  File "/usr/lib/python3.8/site-packages/friture/audioproc.py", line 109, in update_freq_cache
    self.freq = linspace(0, SAMPLING_RATE / (2 * self.decimation), self.fft_size / (2 * self.decimation) + 1)
  File "<__array_function__ internals>", line 5, in linspace
  File "/usr/lib/python3.8/site-packages/numpy/core/function_base.py", line 119, in linspace
    raise TypeError(
TypeError: object of type <class 'float'> cannot be safely interpreted as an integer.

```
