### PR TITLE
Update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ friture.egg-info
 Notepad++
 .idea
 .vscode
+
+.mypy_cache

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -13,8 +13,8 @@ if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
     # workaround for https://github.com/pypa/packaging-problems/issues/134
     # build-time dependencies define in `setup_requires` are resolved
     # on macOS Python with TLSv1, which is now disabled, so that fails
-    pip3 install numpy==1.16.2
-    pip3 install Cython==0.27.3
+    pip3 install numpy==1.19.3
+    pip3 install Cython==0.29.21
 fi
 
 pip3 install -r requirements.txt
@@ -25,7 +25,7 @@ python3 setup.py build_ext --inplace
 if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
     # Macos    
 
-    pip3 install -U pyinstaller==3.5
+    pip3 install -U pyinstaller==4.0
 
     pyinstaller friture.spec -y --onedir --windowed
 
@@ -43,8 +43,7 @@ else
     sudo apt-get install -y libportaudio2
     sudo apt-get install -y desktop-file-utils # for desktop-file-validate, used by pkg2appimage
 
-    # about pep517, see https://github.com/pypa/pip/issues/6163
-    pip3 install -U pyinstaller==3.5 --no-use-pep517
+    pip3 install -U pyinstaller==4.0
 
     pyinstaller friture.spec -y --log-level=DEBUG
 

--- a/friture.spec
+++ b/friture.spec
@@ -84,21 +84,6 @@ excluded_binaries = [
         'QtWebKitWidgets.framework',
         'QtWebSockets.framework']
 
-
-# the manual bundling of libportaudio can be removed once the following PyInstaller MR is released:
-# https://github.com/pyinstaller/pyinstaller/pull/4498
-# (pyinstaller>3.5)
-if platform.system() == "Windows" or platform.system() == "Darwin":
-  sounddevice_data = collect_data_files("sounddevice", subdir="_sounddevice_data")
-  libportaudio = [(f[0], os.path.join("_sounddevice_data", "portaudio-binaries")) for f in sounddevice_data if "libportaudio" in f[0]]
-
-  print(libportaudio)
-  if len(libportaudio) != 1:
-    raise ValueError('libportaudio could not be found')
-else:
-  libportaudio = []
-
-
 if platform.system() == "Windows":
   # workaround for PyInstaller that does not look where the new PyQt5 official wheels put the Qt dlls
   from PyInstaller.compat import getsitepackages
@@ -113,7 +98,7 @@ else:
 a = Analysis(['main.py'],
              pathex=pathex,
              binaries=None,
-             datas=libportaudio,
+             datas=[],
              hiddenimports=[],
              hookspath=[],
              runtime_hooks=[],

--- a/setup.py
+++ b/setup.py
@@ -50,19 +50,19 @@ ext_modules = [LateIncludeExtension("friture_extensions.exp_smoothing_conv",
 # these will be installed when calling 'pip install friture'
 # they are also retrieved by 'requirements.txt'
 install_requires = [
-    "sounddevice==0.3.14",
-    "rtmixer==0.1.0",
-    "PyOpenGL==3.1.4",
-    "PyOpenGL-accelerate==3.1.4",
-    "docutils==0.15.2",
-    "numpy==1.17.4",
-    "PyQt5==5.13.2",
-    "appdirs==1.4.3",
+    "sounddevice==0.4.1",
+    "rtmixer==0.1.2",
+    "PyOpenGL==3.1.5",
+    "PyOpenGL-accelerate==3.1.5",
+    "docutils==0.16",
+    "numpy==1.19.3",
+    "PyQt5==5.15.1",
+    "appdirs==1.4.4",
     "pyrr==0.10.3",
 ]
 
 # Cython and numpy are needed when running setup.py, to build extensions
-setup_requires=["numpy==1.17.4", "Cython==0.29.14"]
+setup_requires=["numpy==1.19.3", "Cython==0.29.21"]
 
 with open(join(dirname(__file__), 'README.rst')) as f:
     long_description = f.read()

--- a/winbuild.ps1
+++ b/winbuild.ps1
@@ -85,7 +85,7 @@ Write-Host "==========================================="
 Write-Host "Installing pyinstaller"
 Write-Host "==========================================="
 
-& pip install -U pyinstaller==3.5
+& pip install -U pyinstaller==4.0
 
 Write-Host ""
 Write-Host "==========================================="


### PR DESCRIPTION
Update the following libraries:
- numpy 1.19.3 (1.19.4 has a bug on Windows - https://developercommunity.visualstudio.com/content/problem/1207405/fmod-after-an-update-to-windows-2004-is-causing-a.html)
- sounddevice 0.4.1
- rtmixer 0.1.2
- PyOpenGL 3.1.5
- PyOpenGL-accelerate 3.1.5
- docutils 0.16
- PyQt5 5.15.1
- appsdirs 1.4.4

And update PyInstaller to 4.0.