### PR TITLE
Update automated builds to Python 3.9.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
 
     steps:
     - name: Checkout
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-16.04
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
 
     steps:
     - name: Checkout
@@ -89,7 +89,7 @@ jobs:
     runs-on: macos-10.15
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
 
     steps:
     - name: Checkout

--- a/.github/workflows/install-linux.sh
+++ b/.github/workflows/install-linux.sh
@@ -14,7 +14,7 @@ sudo apt-get update
 sudo apt-get install -y libportaudio2
 sudo apt-get install -y desktop-file-utils # for desktop-file-validate, used by pkg2appimage
 
-pip3 install -U pyinstaller==4.0
+pip3 install -U pyinstaller==4.1
 
 pyinstaller friture.spec -y --log-level=DEBUG
 

--- a/.github/workflows/install-macos.sh
+++ b/.github/workflows/install-macos.sh
@@ -10,7 +10,7 @@ pip3 install -r requirements.txt
 # pyinstaller needs to have the extensions built explicitely
 python3 setup.py build_ext --inplace
 
-pip3 install -U pyinstaller==4.0
+pip3 install -U pyinstaller==4.1
 
 pyinstaller friture.spec -y --onedir --windowed
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,9 +23,9 @@ sudo apt-get install -y git
 sudo apt-get install -y libportaudio2
 ```
 
-3. Install python 3.8 and related build tools
+3. Install python 3.9 and related build tools
 ```
-sudo apt-get install -y python3.8-dev
+sudo apt-get install -y python3.9-dev
 ```
 
 4. Clone the repository
@@ -43,30 +43,30 @@ git checkout origin/<branchName>
 6. Update `pip`, `setuptools` and `virtualenv`
 
 ```
-sudo python3.8 -m pip install --upgrade pip
-sudo pip3.8 install --upgrade setuptools
-sudo pip3.8 install --upgrade virtualenv
+sudo python3.9 -m pip install --upgrade pip
+sudo pip3.9 install --upgrade setuptools
+sudo pip3.9 install --upgrade virtualenv
 ```
 
 7. Create a virtualenv and activate it
 ```
-virtualenv  -p /usr/bin/python3.8 buildenv
+virtualenv  -p /usr/bin/python3.9 buildenv
 source ./buildenv/bin/activate
 ```
 
 8. Install Friture requirements (PyQt5, etc.)
 ```
-pip3.8 install -r requirements.txt
+pip3.9 install -r requirements.txt
 ```
 
 9. Build Cython extensions
 ```
-python3.8 setup.py build_ext --inplace
+python3.9 setup.py build_ext --inplace
 ```
 
 10. Run Friture
 ```
-python3.8 main.py
+python3.9 main.py
 ```
 
 ## Running Friture from source on Windows

--- a/choco/packages.config
+++ b/choco/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="python" version="3.8.6" />
+    <package id="python" version="3.9.1" />
     <!-- Microsoft Visual Build Tools and C++ workload for Cython, Numpy, etc. -->
     <package id="visualstudio2017buildtools" version="15.9.4.0" />
     <package id="visualstudio2017-workload-vctools" version="1.3.1" packageParameters="--add Microsoft.VisualStudio.Component.VC.140"/>

--- a/friture.spec
+++ b/friture.spec
@@ -90,7 +90,7 @@ if platform.system() == "Windows":
   pathex = [os.path.join(x, 'PyQt5', 'Qt', 'bin') for x in getsitepackages()]
 
   # add vcruntime140.dll - PyInstaller excludes it by default because it thinks it comes from c:\Windows
-  binaries = [('vcruntime140.dll', 'C:\\Python38\\vcruntime140.dll', 'BINARY')]
+  binaries = [('vcruntime140.dll', 'C:\\Python39\\vcruntime140.dll', 'BINARY')]
 else:
   pathex = []
   binaries = []

--- a/winbuild.ps1
+++ b/winbuild.ps1
@@ -85,7 +85,7 @@ Write-Host "==========================================="
 Write-Host "Installing pyinstaller"
 Write-Host "==========================================="
 
-& pip install -U pyinstaller==4.0
+& pip install -U pyinstaller==4.1
 
 Write-Host ""
 Write-Host "==========================================="


### PR DESCRIPTION
Support for Macos Big Sur was only added in Python 3.9.1.
This is a first of the fixes for #154.

Also update to latest pyinstaller.