### PR TITLE
Macos bundle: define  NSMicrophoneUsageDescription

### DIFF
--- a/friture.spec
+++ b/friture.spec
@@ -133,4 +133,5 @@ coll = COLLECT(exe,
 app = BUNDLE(coll,
          name='friture.app',
          icon='resources/images/friture.icns',
-         bundle_identifier=None)
+         bundle_identifier=None,
+         info_plist={'NSMicrophoneUsageDescription': 'Friture reads from the audio inputs to show visualizations'})


### PR DESCRIPTION
According to https://developer.apple.com/documentation/avfoundation/cameras_and_media_capture/requesting_authorization_for_media_capture_on_macos, an app must declare why it needs microphone access.

If the appropriate key is not present in the Info.plist file when the app requests authorization or attempts to use a capture device, the system terminates the app.

Related to #154