### PR TITLE
Macos builds: install latest portaudio

### DIFF
--- a/.github/workflows/install-macos.sh
+++ b/.github/workflows/install-macos.sh
@@ -10,11 +10,21 @@ pip3 install -r requirements.txt
 # pyinstaller needs to have the extensions built explicitely
 python3 setup.py build_ext --inplace
 
+# for Macos Big Sur, the stable portaudio (19.6.0) makes Friture freeze on startup
+# install from latest master instead
+# see: https://github.com/tlecomte/friture/issues/154
+brew install portaudio --HEAD
+
 pip3 install -U pyinstaller==4.2
 
 pyinstaller friture.spec -y --onedir --windowed
 
 ls -la dist/*
+
+# compare the portaudio libs to make sure the package contains the one that was installed with brew
+ls -la /usr/local/lib/libportaudio.dylib
+ls -la /usr/local/Cellar/portaudio/*/lib/libportaudio*.dylib
+ls -la dist/friture.app/Contents/MacOS/_sounddevice_data/portaudio-binaries
 
 # prepare a dmg out of friture.app
 export ARTIFACT_FILENAME=friture-$(python3 -c 'import friture; print(friture.__version__)')-$(date +'%Y%m%d').dmg

--- a/friture.spec
+++ b/friture.spec
@@ -84,23 +84,18 @@ excluded_binaries = [
         'QtWebKitWidgets.framework',
         'QtWebSockets.framework']
 
+pathex = []
 if platform.system() == "Windows":
   # workaround for PyInstaller that does not look where the new PyQt5 official wheels put the Qt dlls
   from PyInstaller.compat import getsitepackages
-  pathex = [os.path.join(x, 'PyQt5', 'Qt', 'bin') for x in getsitepackages()]
-
-  # add vcruntime140.dll - PyInstaller excludes it by default because it thinks it comes from c:\Windows
-  binaries = [('vcruntime140.dll', 'C:\\Python39\\vcruntime140.dll', 'BINARY')]
-else:
-  pathex = []
-  binaries = []
+  pathex += [os.path.join(x, 'PyQt5', 'Qt', 'bin') for x in getsitepackages()]
 
 a = Analysis(['main.py'],
              pathex=pathex,
-             binaries=None,
+             binaries=[],
              datas=[],
              hiddenimports=[],
-             hookspath=[],
+             hookspath=["installer/pyinstaller-hooks"], # our custom hooks for python-sounddevice
              runtime_hooks=[],
              excludes=excludes,
              win_no_prefer_redirects=False,
@@ -123,7 +118,7 @@ exe = EXE(pyz,
           icon="resources/images/friture.ico")
 
 coll = COLLECT(exe,
-               a.binaries + binaries,
+               a.binaries,
                a.zipfiles,
                a.datas,
                strip=False,

--- a/installer/pyinstaller-hooks/hook-sounddevice.py
+++ b/installer/pyinstaller-hooks/hook-sounddevice.py
@@ -1,0 +1,37 @@
+# ------------------------------------------------------------------
+# Copyright (c) 2020 PyInstaller Development Team.
+#
+# This file is distributed under the terms of the GNU General Public
+# License (version 2.0 or later).
+#
+# The full license is available in LICENSE.GPL.txt, distributed with
+# this software.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ------------------------------------------------------------------
+# -----------------------------------------------------------------------------
+
+"""
+sounddevice:
+https://github.com/spatialaudio/python-sounddevice/
+"""
+
+import os
+
+from PyInstaller.compat import is_darwin, is_win
+from PyInstaller.utils.hooks import get_package_paths
+
+sfp = get_package_paths("sounddevice")
+
+path = None
+if is_win:
+    path = os.path.join(sfp[0], "_sounddevice_data", "portaudio-binaries")
+elif is_darwin:
+    # for Macos Big Sur, the stable portaudio (19.6.0) makes Friture freeze on startup
+    path = "/usr/local/lib/libportaudio.dylib"
+    if not os.path.isfile(path):
+        raise ValueError('libportaudio could not be found')
+
+if path is not None and os.path.exists(path):
+    binaries = [(path,
+                 os.path.join("_sounddevice_data", "portaudio-binaries"))]


### PR DESCRIPTION
For Macos Big Sur, the stable portaudio (19.6.0) makes Friture freeze on startup.
So we install from latest master instead, and we tell pyinstaller to bundle that version instead of the version provided by python-sounddevice.
See #154

Also remove the vcruntime140.dll workaround that is not needed with latest pyinstaller, and was getting confusing to apply next to the Macos setting.