### PR TITLE
Linux AppImage: add portaudio

### DIFF
--- a/appimage/friture.yml
+++ b/appimage/friture.yml
@@ -5,8 +5,10 @@ app: friture
 
 ingredients:
   dist: xenial
-  sources: []
-  packages: []
+  sources:
+    - deb http://us.archive.ubuntu.com/ubuntu/ xenial main universe
+  packages:
+    - libportaudio2
 
 script:
   - echo $PWD


### PR DESCRIPTION
The portaudio library is missing from the Linux appimage, requiring users to install portaudio manually, which is not the original intent.

Fixes #108 and #145