### PR TITLE
Do not catch PyOpenGL import errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ venv/*
 tools/*
 friture.egg-info
 .eggs/
+*.appx
 
 ##################
 # IDE files

--- a/friture/plotting/glCanvasWidget.py
+++ b/friture/plotting/glCanvasWidget.py
@@ -1,21 +1,12 @@
 import sys
 import logging
+from ctypes import sizeof, c_float, c_void_p, c_uint
 
 from PyQt5 import QtCore, QtGui, Qt, QtWidgets
 import numpy as np
 import pyrr
-
-try:
-    from OpenGL import GL
-except ImportError:
-    app = QtWidgets.QApplication(sys.argv)
-    QtWidgets.QMessageBox.critical(None, "OpenGL hellogl",
-                                   "PyOpenGL must be installed to run this example.")
-    sys.exit(1)
-
+from OpenGL import GL
 from OpenGL.arrays import vbo
-from ctypes import sizeof, c_float, c_void_p, c_uint
-
 
 def compileProgram(*shaders):
     """Copied from the PyOpenGL codebase, as suggested in the PyOpenGL doc.

--- a/friture/plotting/quadsItem.py
+++ b/friture/plotting/quadsItem.py
@@ -18,18 +18,11 @@
 # along with Friture.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
-from PyQt5 import QtWidgets
-
-try:
-    from OpenGL import GL
-except ImportError:
-    app = QtWidgets.QApplication(sys.argv)
-    QtWidgets.QMessageBox.critical(None, "OpenGL hellogl",
-                                   "PyOpenGL must be installed to run this example.")
-    sys.exit(1)
-
-from OpenGL.GL import shaders
 from ctypes import c_float, c_uint, c_void_p, sizeof
+
+from PyQt5 import QtWidgets
+from OpenGL import GL
+from OpenGL.GL import shaders
 import numpy as np
 
 

--- a/friture/timeplot.py
+++ b/friture/timeplot.py
@@ -19,26 +19,18 @@
 
 import sys
 import logging
+from ctypes import sizeof, c_float, c_void_p, c_uint
 
 from PyQt5 import Qt, QtGui, QtWidgets
 import numpy as np
+from OpenGL import GL
+from OpenGL.GL import shaders
+
 from friture.plotting.scaleWidget import VerticalScaleWidget, HorizontalScaleWidget
 from friture.plotting.scaleDivision import ScaleDivision
 from friture.plotting.coordinateTransform import CoordinateTransform
 from friture.plotting.glCanvasWidget import GlCanvasWidget
 from friture.plotting.legendWidget import LegendWidget
-
-try:
-    from OpenGL import GL
-except ImportError:
-    app = QtWidgets.QApplication(sys.argv)
-    QtWidgets.QMessageBox.critical(None, "OpenGL hellogl",
-                                   "PyOpenGL must be installed to run this example.")
-    sys.exit(1)
-
-from OpenGL.GL import shaders
-from ctypes import sizeof, c_float, c_void_p, c_uint
-
 
 class CurveItem:
 

--- a/sandbox/2dpainting.py
+++ b/sandbox/2dpainting.py
@@ -28,14 +28,7 @@ import sys
 import math
 
 from PyQt4 import QtCore, QtGui, QtOpenGL
-
-try:
-    from OpenGL import GL
-except ImportError:
-    app = QtGui.QApplication(sys.argv)
-    QtGui.QMessageBox.critical(None, "OpenGL 2dpainting",
-            "PyOpenGL must be installed to run this example.")
-    sys.exit(1)
+from OpenGL import GL
 
 class GLWidget(QtOpenGL.QGLWidget):
     def __init__(self, parent):

--- a/sandbox/hellogl.py
+++ b/sandbox/hellogl.py
@@ -7,14 +7,7 @@ import sys
 import math
 
 from PyQt4 import QtCore, QtGui, QtOpenGL
-
-try:
-    from OpenGL import GL
-except ImportError:
-    app = QtGui.QApplication(sys.argv)
-    QtGui.QMessageBox.critical(None, "OpenGL hellogl",
-            "PyOpenGL must be installed to run this example.")
-    sys.exit(1)
+from OpenGL import GL
 
 
 class Window(QtGui.QWidget):


### PR DESCRIPTION
Improvement to address #170

Catching PyOpenGL import errors might hide a bigger problem. The packages that we build are meant to include it anyway, so it's better to get the original full error.

That piece of code was a leftover from the PyOpenGL samples that were used originally.