### PR TITLE
Fix starting application without any docks

### DIFF
--- a/friture/analyzer.py
+++ b/friture/analyzer.py
@@ -198,6 +198,8 @@ class Friture(QMainWindow, ):
         # 2. remove any level widget
         if settings.contains("Docks/dockNames"):
             docknames = settings.value("Docks/dockNames", [])
+            if docknames == None:
+            	docknames = []
             newDockNames = []
             for dockname in docknames:
                 widgetType = settings.value("Docks/" + dockname + "/type", 0, type=int)

--- a/friture/analyzer.py
+++ b/friture/analyzer.py
@@ -197,7 +197,7 @@ class Friture(QMainWindow, ):
 
         # 2. remove any level widget
         if settings.contains("Docks/dockNames"):
-            docknames = settings.value("Docks/dockNames")
+            docknames = settings.value("Docks/dockNames", [])
             newDockNames = []
             for dockname in docknames:
                 widgetType = settings.value("Docks/" + dockname + "/type", 0, type=int)


### PR DESCRIPTION
Addressing issue #92. When removing all docks and closing the application, i found the following value in my Friture.conf

```
[Docks]
Dock%201\timeRange=50
Dock%201\type=1
dockNames=@Invalid()
```

While i did not find a way to prevent the invalid value in the config file, i did find a way to handle the invalid one upon starting the application.

Tested on a linux system