### PR TITLE
Update numpy requirement from 1.19.3 to 1.20.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,14 +55,14 @@ install_requires = [
     "PyOpenGL==3.1.5",
     "PyOpenGL-accelerate==3.1.5",
     "docutils==0.16",
-    "numpy==1.19.3",
+    "numpy==1.20.3",
     "PyQt5==5.15.3",
     "appdirs==1.4.4",
     "pyrr==0.10.3",
 ]
 
 # Cython and numpy are needed when running setup.py, to build extensions
-setup_requires=["numpy==1.19.3", "Cython==0.29.21"]
+setup_requires=["numpy==1.20.3", "Cython==0.29.21"]
 
 with open(join(dirname(__file__), 'README.rst')) as f:
     long_description = f.read()


### PR DESCRIPTION
There is an ABI compatibility issue on some platforms involving the interaction between the Cython-generated shared object files included in the OpenGL-accelerate 3.1.5 and numpy 1.19.3 PyPI packages which can cause a missing symbol error during import.
This causes friture to throw an exception On MacOS Big Sur and Windows during startup.

Fixes two reports of the issue here:  https://github.com/tlecomte/friture/issues/177
And (probably) this one without the logs also:  https://github.com/tlecomte/friture/issues/170.
  (I see the same symptom when I try to install the downloadable fricture dmg file on Big Sur)

I don't have a full understanding of the underlying issue, or a full list of which platforms it affects, but I can confirm from my testing on Big Sur that updating the requirements to numpy 1.20.3 fixes the problem there.

Even without friture, the problem can be reproduced in a clean virtualenv by simply installing both pip packages and trying to import like this:

from OpenGL_accelerate.numpy_formathandler import NumpyHandler

It will fail due to this error:
```
ValueError: ('numpy.ndarray size changed, may indicate binary incompatibility. Expected 88 from C header, got 80 from PyObject', 1, <OpenGL.platform.baseplatform.glGetIntegerv object at 0x13f2b60c0>)
```
And then if you silence that one, it runs into this error instead:
```
File "src/numpy_formathandler.pyx", line 39, in init OpenGL_accelerate.numpy_formathandler
AttributeError: type object 'OpenGL_accelerate.numpy_formathandler.NumpyHandler' has no attribute '__reduce_cython__'
```
My guess is that they may have been compiled with different versions of Cython, where there was a change to the way it handles the pickling of classes (replaces `__reduce_cython__` with `__reduce__` at runtime), but not sure how to confirm that since the pip packages only include the `.so` files, not the intermediate `.c` files.