### PR TITLE
chore: update to PyInstaller 4.4

### DIFF
--- a/.github/workflows/install-linux.sh
+++ b/.github/workflows/install-linux.sh
@@ -14,7 +14,7 @@ sudo apt-get update
 sudo apt-get install -y libportaudio2
 sudo apt-get install -y desktop-file-utils # for desktop-file-validate, used by pkg2appimage
 
-pip3 install -U pyinstaller==4.2
+pip3 install -U pyinstaller==4.4
 
 pyinstaller friture.spec -y --log-level=DEBUG
 

--- a/.github/workflows/install-macos.sh
+++ b/.github/workflows/install-macos.sh
@@ -15,7 +15,7 @@ python3 setup.py build_ext --inplace
 # see: https://github.com/tlecomte/friture/issues/154
 brew install portaudio --HEAD
 
-pip3 install -U pyinstaller==4.2
+pip3 install -U pyinstaller==4.4
 
 pyinstaller friture.spec -y --onedir --windowed
 

--- a/winbuild.ps1
+++ b/winbuild.ps1
@@ -85,7 +85,7 @@ Write-Host "==========================================="
 Write-Host "Installing pyinstaller"
 Write-Host "==========================================="
 
-& pip install -U pyinstaller==4.2
+& pip install -U pyinstaller==4.4
 
 Write-Host ""
 Write-Host "==========================================="


### PR DESCRIPTION
This may help for MacOS packages, since there has been a couple of improvements in that area.