### PR TITLE
Fix spectrogram frequency scale by removing borders

### DIFF
--- a/friture/imageplot.py
+++ b/friture/imageplot.py
@@ -229,8 +229,6 @@ class ImagePlot(QtWidgets.QWidget):
 
             self.verticalScaleDivision.setLength(self.canvasWidget.height())
             self.verticalScaleTransform.setLength(self.canvasWidget.height())
-            startBorder, endBorder = self.verticalScale.spacingBorders()
-            self.verticalScaleTransform.setBorders(startBorder, endBorder)
 
             self.verticalScale.update()
 

--- a/friture/plotting/scaleBar.py
+++ b/friture/plotting/scaleBar.py
@@ -88,8 +88,9 @@ class VerticalScaleBar(QtWidgets.QWidget):
             # for vertical scale we invert the coordinates
             y = self.height() - self.coordinateTransform.toScreen(tick)
             painter.drawLine(xt, y, xb, y)
-            tick_string = self.tickFormatter(tick, digits)
-            painter.drawText(le - fm.width(tick_string), y + lh / 2 - 2, tick_string)
+            if self.coordinateTransform.startBorder < y < self.coordinateTransform.length - self.coordinateTransform.endBorder:
+                tick_string = self.tickFormatter(tick, digits)
+                painter.drawText(le - fm.width(tick_string), y + lh / 2 - 2, tick_string)
 
         for tick in self.scaleDivision.minorTicks():
             # for vertical scale we invert the coordinates


### PR DESCRIPTION
Fixes #191 by removing the borders around the frequency scale. Additionally, a check to avoid text being drawn beyond the widget area is implemented in `scaleBar.py`.