### PR TITLE
Collection of QML fixes

### DIFF
--- a/friture/Levels.qml
+++ b/friture/Levels.qml
@@ -11,8 +11,8 @@ Rectangle {
     property var stateId
     property LevelViewModel level_view_model: Store.dock_states[stateId]  
 
-    anchors.top: parent.top
-    anchors.bottom: parent.bottom
+    // parent here will be unset on exit
+    height: parent ? parent.height : 0
 
     // make width dependent on the text labels
     // but do not bind directly to their widths

--- a/friture/Levels.qml
+++ b/friture/Levels.qml
@@ -30,8 +30,7 @@ Rectangle {
         id: levelColumnLayout
         spacing: 6
 
-        anchors.top: parent.top
-        anchors.bottom: parent.bottom
+        anchors.fill: parent
 
         Text {
             id: peakValues

--- a/friture/analyzer.py
+++ b/friture/analyzer.py
@@ -28,8 +28,8 @@ import logging.handlers
 from PyQt5 import QtCore
 # specifically import from PyQt5.QtGui and QWidgets for startup time improvement :
 from PyQt5.QtWidgets import QMainWindow, QHBoxLayout, QApplication, QSplashScreen
-from PyQt5.QtGui import QPixmap, QSurfaceFormat
-from PyQt5.QtQml import QQmlApplicationEngine, qmlRegisterSingletonType, qmlRegisterType
+from PyQt5.QtGui import QPixmap
+from PyQt5.QtQml import QQmlEngine, qmlRegisterSingletonType, qmlRegisterType
 import appdirs
 
 # importing friture.exceptionhandler also installs a temporary exception hook
@@ -72,14 +72,20 @@ class Friture(QMainWindow, ):
     def __init__(self):
         QMainWindow.__init__(self)
 
-        self.logger = logging.getLogger(__name__)
+        self.logger = logging.getLogger(__name__)        
 
         # exception hook that logs to console, file, and display a message box
         self.errorDialogOpened = False
         sys.excepthook = self.excepthook
+        
+        store = GetStore()
 
-        #engine = QQmlEngine()
-        self.qml_engine = QQmlApplicationEngine()
+        # set the store as the parent of the QML engine
+        # so that the store outlives the engine
+        # otherwise the store gets destroyed before the engine
+        # which refreshes the QML bindings to undefined values
+        # and QML errors are raised
+        self.qml_engine = QQmlEngine(store)
 
         # Register the ScaleDivision type.  Its URI is 'ScaleDivision', it's v1.0 and the type
         # will be called 'Person' in QML.

--- a/friture/axis.py
+++ b/friture/axis.py
@@ -12,8 +12,8 @@ class Axis(QtCore.QObject):
 
         self._name = "Axis Name"
         self._formatter = lambda x: str(x)
-        self._scale_division = ScaleDivision(-1., 1.)
-        self._coordinate_transform = CoordinateTransform(-1, 1, 1., 0, 0)
+        self._scale_division = ScaleDivision(-1., 1., self)
+        self._coordinate_transform = CoordinateTransform(-1, 1, 1., 0, 0, self)
 
     @pyqtProperty(str, notify=name_changed)
     def name(self):

--- a/friture/levels.py
+++ b/friture/levels.py
@@ -60,11 +60,13 @@ class Levels_Widget(QtWidgets.QWidget):
         initialProperties = {"parent": self.quickWindow.contentItem(), "stateId": state_id }
         self.qmlObject = component.createWithInitialProperties(initialProperties, engineContext)
         self.qmlObject.setParent(self.quickWindow)
-        self.qmlObject.widthChanged.connect(self.onWidthChanged)
 
         self.quickWidget = QtWidgets.QWidget.createWindowContainer(self.quickWindow, self)
         self.quickWidget.setSizePolicy(QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Expanding)       
         self.gridLayout.addWidget(self.quickWidget)
+
+        self.qmlObject.widthChanged.connect(self.onWidthChanged)
+        self.onWidthChanged()
 
         self.audiobuffer = None
 

--- a/friture/levels.py
+++ b/friture/levels.py
@@ -47,13 +47,13 @@ class Levels_Widget(QtWidgets.QWidget):
         self.gridLayout = QtWidgets.QVBoxLayout(self)
         self.gridLayout.setObjectName("gridLayout")
 
-        self.level_view_model = LevelViewModel(self)
         store = GetStore()
+        self.level_view_model = LevelViewModel(store)
         store._dock_states.append(self.level_view_model)
         state_id = len(store._dock_states) - 1
 
         self.quickWindow = QQuickWindow()
-        component = QQmlComponent(engine, qml_url("Levels.qml"))
+        component = QQmlComponent(engine, qml_url("Levels.qml"), self)
         raise_if_error(component)
 
         engineContext = engine.rootContext()

--- a/friture/longlevels.py
+++ b/friture/longlevels.py
@@ -119,9 +119,10 @@ class LongLevelWidget(QtWidgets.QWidget):
         self.setObjectName("Scope_Widget")
         self.gridLayout = QtWidgets.QGridLayout(self)
         self.gridLayout.setObjectName("gridLayout")
+        self.gridLayout.setContentsMargins(2, 2, 2, 2)
 
         self.quickWidget = QQuickWidget(engine, self)
-        #self.quickWidget.statusChanged.connect(self.on_status_changed)
+        self.quickWidget.statusChanged.connect(self.on_status_changed)
         self.quickWidget.setResizeMode(QQuickWidget.SizeRootObjectToView)
         self.quickWidget.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
         self.quickWidget.setSource(qml_url("Scope.qml"))

--- a/friture/plotting/coordinateTransform.py
+++ b/friture/plotting/coordinateTransform.py
@@ -27,8 +27,8 @@ import friture.plotting.frequency_scales as fscales
 
 class CoordinateTransform(QtCore.QObject):
 
-    def __init__(self, coord_min, coord_max, length, startBorder, endBorder):
-        super(CoordinateTransform, self).__init__()
+    def __init__(self, coord_min, coord_max, length, startBorder, endBorder, parent=None):
+        super(CoordinateTransform, self).__init__(parent)
 
         self.coord_min = coord_min
         self.coord_max = coord_max

--- a/friture/scope.py
+++ b/friture/scope.py
@@ -62,6 +62,7 @@ class Scope_Widget(QtWidgets.QWidget):
         self.setObjectName("Scope_Widget")
         self.gridLayout = QtWidgets.QGridLayout(self)
         self.gridLayout.setObjectName("gridLayout")
+        self.gridLayout.setContentsMargins(2, 2, 2, 2)
 
         self.quickWidget = QQuickWidget(engine, self)
         self.quickWidget.statusChanged.connect(self.on_status_changed)
@@ -72,7 +73,7 @@ class Scope_Widget(QtWidgets.QWidget):
 
         self.quickWidget.rootObject().setProperty("stateId", state_id)
 
-        self.gridLayout.addWidget(self.quickWidget, 0, 0, 1, 1)
+        self.gridLayout.addWidget(self.quickWidget)
 
         self.settings_dialog = Scope_Settings_Dialog(self)
 

--- a/friture/scope_data.py
+++ b/friture/scope_data.py
@@ -32,8 +32,8 @@ class Scope_Data(QtCore.QObject):
         super().__init__(parent)
 
         self._plot_items = []
-        self._horizontal_axis = Axis()
-        self._vertical_axis = Axis()
+        self._horizontal_axis = Axis(self)
+        self._vertical_axis = Axis(self)
         self._show_legend = True
 
     @pyqtProperty(QQmlListProperty, notify=plot_items_changed)

--- a/friture/spectrum.py
+++ b/friture/spectrum.py
@@ -47,6 +47,7 @@ class Spectrum_Widget(QtWidgets.QWidget):
         self.setObjectName("Spectrum_Widget")
         self.gridLayout = QtWidgets.QGridLayout(self)
         self.gridLayout.setObjectName("gridLayout")
+        self.gridLayout.setContentsMargins(2, 2, 2, 2)
         self.PlotZoneSpect = SpectrumPlotWidget(self, engine)
         self.PlotZoneSpect.setObjectName("PlotZoneSpect")
         self.gridLayout.addWidget(self.PlotZoneSpect, 0, 0, 1, 1)


### PR DESCRIPTION
A collection of fixes to gold plate the migration to QML:

- Fix size and alignement of the levels (they failed to appear sometimes and right-alignment was missing)
- Fix layout margins (they were too big)
- Fix "Cannot read property ... of null" errors on exit and related python crashes by adjusting the object parents to get the proper lifetimes