### PR TITLE
Include additional files in setuptools package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,5 @@ include PROFILING.txt
 include README.rst
 include TODO.txt
 include friture.py
+recursive-include friture *.qml
+recursive-include friture *.js

--- a/setup.py
+++ b/setup.py
@@ -96,5 +96,6 @@ setup(name="friture",
       ext_modules=ext_modules,
       install_requires=install_requires,
       setup_requires=setup_requires,
+      include_package_data=True,
       data_files = [('share/applications', ['appimage/friture.desktop'])],
 )


### PR DESCRIPTION
This PR includes a couple of additional files from the QML changes in the Python package generated by setuptools. The fact that they were missing caused problem's with the packaging mechanism of my Linux distro (NixOS) as it is based on running `python setup.py install`, and will likely also cause issues with other distros such as with [the friture AUR package from Arch Linux](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=friture).