### PR TITLE
python3.10: numpy update and explicit int()

### DIFF
--- a/friture/levels.py
+++ b/friture/levels.py
@@ -105,7 +105,7 @@ class Levels_Widget(QtWidgets.QWidget):
         self.i = 0
 
     def onWidthChanged(self):
-        self.quickWidget.setFixedWidth(self.qmlObject.width())
+        self.quickWidget.setFixedWidth(int(self.qmlObject.width()))
 
     # method
     def set_buffer(self, buffer):

--- a/friture/plotting/coordinateTransform.py
+++ b/friture/plotting/coordinateTransform.py
@@ -58,25 +58,31 @@ class CoordinateTransform(QtCore.QObject):
     def setScale(self, scale):
         self.scale = scale
 
-    @pyqtSlot(float, result=float)
+    @pyqtSlot(float, result=int)
     def toScreen(self, x):
         if self.scale is fscales.Logarithmic:
             if self.coord_clipped_min == self.coord_clipped_max:
-                return self.startBorder + 0. * x  # keep x type (this can produce a RunTimeWarning if x contains inf)
+                return int(self.startBorder + 0. * x)  # keep x type (this can produce a RunTimeWarning if x contains inf)
 
             x = (x < 1e-20) * 1e-20 + (x >= 1e-20) * x
-            return (np.log10(x / self.coord_clipped_min)) * (self.length - self.startBorder - self.endBorder) / self.coord_ratio_log + self.startBorder
+            return int((np.log10(x / self.coord_clipped_min))
+                       * (self.length - self.startBorder - self.endBorder)
+                       / self.coord_ratio_log
+                       + self.startBorder)
         else:
             if self.coord_max == self.coord_min:
-                return self.startBorder + 0. * x  # keep x type (this can produce a RunTimeWarning if x contains inf)
+                return int(self.startBorder + 0. * x)  # keep x type (this can produce a RunTimeWarning if x contains inf)
             
             trans_x = self.scale.transform(x)
             trans_min = self.scale.transform(self.coord_min)
             trans_max = self.scale.transform(self.coord_max)
 
-            return (trans_x - trans_min) * (self.length - self.startBorder - self.endBorder) / (trans_max - trans_min) + self.startBorder
+            return int((trans_x - trans_min)
+                       * (self.length - self.startBorder - self.endBorder)
+                       / (trans_max - trans_min)
+                       + self.startBorder)
 
-    @pyqtSlot(float, result=float)
+    @pyqtSlot(int, result=float)
     def toPlot(self, x):
         if self.length == self.startBorder + self.endBorder:
             return self.coord_min + 0. * x  # keep x type (this can produce a RunTimeWarning if x contains inf)

--- a/friture/plotting/scaleBar.py
+++ b/friture/plotting/scaleBar.py
@@ -69,7 +69,7 @@ class VerticalScaleBar(QtWidgets.QWidget):
 
         # tick start
         xt = xb - self.tickLength
-        xtm = xb - self.tickLength / 2
+        xtm = xb - self.tickLength // 2
 
         # label end
         le = xt - self.labelSpacing
@@ -90,7 +90,7 @@ class VerticalScaleBar(QtWidgets.QWidget):
             painter.drawLine(xt, y, xb, y)
             if self.coordinateTransform.startBorder < y < self.coordinateTransform.length - self.coordinateTransform.endBorder:
                 tick_string = self.tickFormatter(tick, digits)
-                painter.drawText(le - fm.width(tick_string), y + lh / 2 - 2, tick_string)
+                painter.drawText(le - fm.width(tick_string), y + lh // 2 - 2, tick_string)
 
         for tick in self.scaleDivision.minorTicks():
             # for vertical scale we invert the coordinates
@@ -160,7 +160,7 @@ class HorizontalScaleBar(QtWidgets.QWidget):
 
         # tick start
         yt = yb + self.tickLength
-        ytm = yb + self.tickLength / 2
+        ytm = yb + self.tickLength // 2
 
         # label end
         le = yt + self.labelSpacing
@@ -179,7 +179,7 @@ class HorizontalScaleBar(QtWidgets.QWidget):
             x = self.coordinateTransform.toScreen(tick)
             painter.drawLine(x, yt, x, yb)
             tick_string = '{0:.{1}f}'.format(tick, digits)
-            painter.drawText(x - fm.width(tick_string) / 2, le + fm.height(), tick_string)
+            painter.drawText(x - fm.width(tick_string) // 2, le + fm.height(), tick_string)
 
         for tick in self.scaleDivision.minorTicks():
             # for vertical scale we invert the coordinates
@@ -209,7 +209,10 @@ class ColorScaleBar(QtWidgets.QWidget):
 
         # should be shared with spectrogram_image in a dedicated class
         cmap = generated_cmrmap.CMAP
-        self.colors = [QtGui.QColor(cmap[i, 0] * 255, cmap[i, 1] * 255, cmap[i, 2] * 255) for i in range(cmap.shape[0])]
+        self.colors = [QtGui.QColor(int(cmap[i, 0] * 255),
+                                    int(cmap[i, 1] * 255),
+                                    int(cmap[i, 2] * 255)
+                       ) for i in range(cmap.shape[0])]
 
         # for vertical scale bar
         self.setSizePolicy(QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Minimum))
@@ -263,7 +266,7 @@ class ColorScaleBar(QtWidgets.QWidget):
 
         # tick start
         xt = xb + self.tickLength
-        xtm = xb + self.tickLength / 2
+        xtm = xb + self.tickLength // 2
 
         # label start
         ls = xt + self.labelSpacing
@@ -283,7 +286,7 @@ class ColorScaleBar(QtWidgets.QWidget):
             y = self.height() - self.coordinateTransform.toScreen(tick)
             painter.drawLine(xt, y, xb, y)
             tick_string = '{0:.{1}f}'.format(tick, digits)
-            painter.drawText(ls, y + lh / 2 - 2, tick_string)
+            painter.drawText(ls, y + lh // 2 - 2, tick_string)
 
         for tick in self.scaleDivision.minorTicks():
             # for vertical scale we invert the coordinates

--- a/friture/plotting/titleWidget.py
+++ b/friture/plotting/titleWidget.py
@@ -25,7 +25,7 @@ class VerticalTitleWidget(QtWidgets.QWidget):
     def sizeHint(self):
         fm = QtGui.QFontMetrics(self.font())
         # for vertical title
-        return QtCore.QSize(fm.height() * 1.2, fm.width(self.title))
+        return QtCore.QSize(int(fm.height() * 1.2), fm.width(self.title))
 
     def paintEvent(self, paintEvent):
         painter = QtGui.QPainter(self)
@@ -33,9 +33,9 @@ class VerticalTitleWidget(QtWidgets.QWidget):
 
         # for vertical title
         fm = painter.fontMetrics()
-        centeredTextShift = QtCore.QPoint(-fm.width(self.title) / 2, 0)
+        centeredTextShift = QtCore.QPoint(-fm.width(self.title) // 2, 0)
 
-        painter.translate(fm.height() / 1.2, self.height() / 2)
+        painter.translate(fm.height() // 1.2, self.height() / 2)
         painter.rotate(-90)
         painter.translate(centeredTextShift)
 
@@ -63,16 +63,16 @@ class HorizontalTitleWidget(QtWidgets.QWidget):
     def sizeHint(self):
         fm = QtGui.QFontMetrics(self.font())
         # for vertical title
-        return QtCore.QSize(fm.width(self.title), fm.height() * 1.2)
+        return QtCore.QSize(fm.width(self.title), int(fm.height() * 1.2))
 
     def paintEvent(self, paintEvent):
         painter = QtGui.QPainter(self)
         # painter.setRenderHint(QtGui.QPainter.Antialiasing)
 
         fm = painter.fontMetrics()
-        centeredTextShift = QtCore.QPoint(-fm.width(self.title) / 2, 0)
+        centeredTextShift = QtCore.QPoint(-fm.width(self.title) // 2, 0)
 
-        painter.translate(self.width() / 2, fm.height())
+        painter.translate(self.width() // 2, fm.height())
         painter.translate(centeredTextShift)
 
         painter.drawText(0, 0, self.title)
@@ -100,7 +100,7 @@ class ColorTitleWidget(QtWidgets.QWidget):
     def sizeHint(self):
         fm = QtGui.QFontMetrics(self.font())
         # for vertical title
-        return QtCore.QSize(fm.height() * 1.5, fm.width(self.title))
+        return QtCore.QSize(int(fm.height() * 1.5), fm.width(self.title))
 
     def paintEvent(self, paintEvent):
         painter = QtGui.QPainter(self)
@@ -108,9 +108,9 @@ class ColorTitleWidget(QtWidgets.QWidget):
 
         # for vertical title
         fm = painter.fontMetrics()
-        centeredTextShift = QtCore.QPoint(-fm.width(self.title) / 2, 0)
+        centeredTextShift = QtCore.QPoint(-fm.width(self.title) // 2, 0)
 
-        painter.translate(self.width() / 2, self.height() / 2)
+        painter.translate(self.width() // 2, self.height() / 2)
         painter.rotate(90)
         painter.translate(centeredTextShift)
 

--- a/friture/spectrogram_image.py
+++ b/friture/spectrogram_image.py
@@ -61,7 +61,7 @@ class CanvasScaledSpectrogram(QtCore.QObject):
 
     # resize the pixmap and update the offsets accordingly
     def resize(self, width, height):
-        oldWidth = self.pixmap.width() / 2
+        oldWidth = int(self.pixmap.width() / 2)
         if width != oldWidth:
             self.offset = (self.offset % oldWidth) * width / oldWidth
             self.offset = self.offset % width  # to handle negative values
@@ -69,17 +69,17 @@ class CanvasScaledSpectrogram(QtCore.QObject):
         self.pixmap = self.pixmap.scaled(2 * width, height, QtCore.Qt.IgnoreAspectRatio, QtCore.Qt.SmoothTransformation)
 
     def setcanvas_height(self, canvas_height):
-        if self.canvas_height != canvas_height:
-            self.canvas_height = canvas_height
+        if self.canvas_height != int(canvas_height):
+            self.canvas_height = int(canvas_height)
             self.resize(self.canvas_width, self.canvas_height)
-            self.logger.info("Spectrogram image: canvas_height changed, now: %d", canvas_height)
+            self.logger.info("Spectrogram image: canvas_height changed, now: %d", int(canvas_height))
 
     def setcanvas_width(self, canvas_width):
-        if self.canvas_width != canvas_width:
-            self.canvas_width = canvas_width
+        if self.canvas_width != int(canvas_width):
+            self.canvas_width = int(canvas_width)
             self.resize(self.canvas_width, self.canvas_height)
-            self.canvasWidthChanged.emit(canvas_width)
-            self.logger.info("Spectrogram image: canvas_width changed, now: %d", canvas_width)
+            self.canvasWidthChanged.emit(int(canvas_width))
+            self.logger.info("Spectrogram image: canvas_width changed, now: %d", int(canvas_width))
 
     def addPixelAdvance(self, pixel_advance):
         self.time_offset += pixel_advance
@@ -148,7 +148,9 @@ class CanvasScaledSpectrogram(QtCore.QObject):
         self.colors = numpy.zeros((cmap.shape[0]), dtype=numpy.uint32)
 
         for i in range(cmap.shape[0]):
-            self.colors[i] = QtGui.QColor(cmap[i, 0] * 255, cmap[i, 1] * 255, cmap[i, 2] * 255).rgb()
+            self.colors[i] = QtGui.QColor(int(cmap[i, 0] * 255),
+                                          int(cmap[i, 1] * 255),
+                                          int(cmap[i, 2] * 255)).rgb()
 
     def color_from_float(self, v):
         # clip in [0..1] before using the fast lookup function

--- a/friture/spectrogram_settings.py
+++ b/friture/spectrogram_settings.py
@@ -75,7 +75,7 @@ class Spectrogram_Settings_Dialog(QtWidgets.QDialog):
 
         self.spinBox_minfreq = QtWidgets.QSpinBox(self)
         self.spinBox_minfreq.setMinimum(20)
-        self.spinBox_minfreq.setMaximum(SAMPLING_RATE / 2)
+        self.spinBox_minfreq.setMaximum(SAMPLING_RATE // 2)
         self.spinBox_minfreq.setSingleStep(10)
         self.spinBox_minfreq.setValue(DEFAULT_MINFREQ)
         self.spinBox_minfreq.setObjectName("spinBox_minfreq")
@@ -83,7 +83,7 @@ class Spectrogram_Settings_Dialog(QtWidgets.QDialog):
 
         self.spinBox_maxfreq = QtWidgets.QSpinBox(self)
         self.spinBox_maxfreq.setMinimum(20)
-        self.spinBox_maxfreq.setMaximum(SAMPLING_RATE / 2)
+        self.spinBox_maxfreq.setMaximum(SAMPLING_RATE // 2)
         self.spinBox_maxfreq.setSingleStep(1000)
         self.spinBox_maxfreq.setProperty("value", DEFAULT_MAXFREQ)
         self.spinBox_maxfreq.setObjectName("spinBox_maxfreq")

--- a/setup.py
+++ b/setup.py
@@ -53,14 +53,14 @@ install_requires = [
     "sounddevice==0.4.2",
     "rtmixer==0.1.3",
     "docutils==0.17.1",
-    "numpy==1.21.1",
+    "numpy>=1.21.1",
     "PyQt5==5.15.4",
     "appdirs==1.4.4",
     "pyrr==0.10.3",
 ]
 
 # Cython and numpy are needed when running setup.py, to build extensions
-setup_requires=["numpy==1.21.1", "Cython==0.29.24"]
+setup_requires=["numpy>=1.21.1", "Cython==0.29.24"]
 
 with open(join(dirname(__file__), 'README.rst')) as f:
     long_description = f.read()


### PR DESCRIPTION
- In Python 3.10, the Numpy C extensions refuse to build; this is fixed by setting the dependency to `numpy>=1.21.1`.
- Implicit conversions to int are deprecated and [enforced](https://bugs.python.org/issue37999), as of Python 2.10. I think I have removed all implicit conversions from float to int, but I might've missed some, or done something in the wrong way. Review would be appreciated.

Fixes #204.
Fixes #206.