### PR TITLE
feat(MacOS): try 'onefile' to workaround codesign issues

### DIFF
--- a/.github/workflows/install-macos.sh
+++ b/.github/workflows/install-macos.sh
@@ -17,7 +17,7 @@ brew install portaudio --HEAD
 
 pip3 install -U pyinstaller==4.10
 
-pyinstaller friture.spec -y --onedir --windowed
+pyinstaller friture.spec -y --onefile --windowed
 
 ls -la dist/*
 


### PR DESCRIPTION
Code signing is mandatory for recent macos versions. However the codesign command currently fails due to the Qt5 folder names containing periods. With the onefile option, we believe all files will be in a single executable, removing the folder name issues.