### PR TITLE
fix(AppImage): build PortAudio 19.7.0 and fix Qt5 dependencies

### DIFF
--- a/.github/workflows/install-linux.sh
+++ b/.github/workflows/install-linux.sh
@@ -11,8 +11,28 @@ pip3 install -r requirements.txt
 python3 setup.py build_ext --inplace
 
 sudo apt-get update
-sudo apt-get install -y libportaudio2
 sudo apt-get install -y desktop-file-utils # for desktop-file-validate, used by pkg2appimage
+
+# when PyInstaller collect libraries, it ignores libraries that are not found on the host.
+# Those missing libs prevent proper startup.
+# For example, PyQt5 bundles Qt5 libs that depend on libxcb-xinerama.so.0
+# which would not be bundled unless explicitly installed.
+sudo apt-get install libxcb-xinerama0
+sudo apt-get install libxkbcommon-x11-0
+
+# dependencies to build PortAudio
+sudo apt-get install -y libasound-dev
+sudo apt-get install -y libjack-dev
+
+# build PortAudio 19.7.0 from scratch (required for Jack fixes on distributions using PipeWire)
+wget https://github.com/PortAudio/portaudio/archive/refs/tags/v19.7.0.tar.gz
+tar -xvf v19.7.0.tar.gz
+cd portaudio-19.7.0
+./configure --prefix=$PWD/portaudio-install
+make
+make install
+ls -laR portaudio-install
+cd ..
 
 pip3 install -U pyinstaller==4.10
 

--- a/appimage/friture.yml
+++ b/appimage/friture.yml
@@ -4,9 +4,9 @@
 app: friture
 
 ingredients:
-  dist: xenial
+  dist: bionic
   sources:
-    - deb http://us.archive.ubuntu.com/ubuntu/ xenial main universe
+    - deb http://us.archive.ubuntu.com/ubuntu/ bionic main universe
   packages:
     - libportaudio2
 

--- a/appimage/friture.yml
+++ b/appimage/friture.yml
@@ -8,10 +8,20 @@ ingredients:
   sources:
     - deb http://us.archive.ubuntu.com/ubuntu/ bionic main universe
   packages:
-    - libportaudio2
+    # portaudio dependencies
+    # (although we build portaudio from scratch, we still need the dependencies)
+    - libasound2
+    - libc6
+    - libjack-jackd2-0
 
 script:
   - echo $PWD
   - cp ../../../appimage/friture.desktop .
   - cp ../../../resources/images-src/window-icon.svg friture.svg
   - cp -R ../../../dist/friture/* usr/bin/
+  - cp -R ../../../portaudio-19.7.0/portaudio-install/lib/libportaudio.so* usr/lib/x86_64-linux-gnu
+  # adjust LD_LIBRARY_PATH so that ctypes.find_library finds portaudio
+  - echo '#!/bin/bash
+  - HERE="$(dirname "$(readlink -f "${0}")")"
+  - export LD_LIBRARY_PATH="$HERE/usr/lib/x86_64-linux-gnu":$LD_LIBRARY_PATH
+  - "$HERE/usr/bin/friture" "$@" | cat' > AppRun


### PR DESCRIPTION
Apply a collection of fixes to make the AppImage work correctly:
-  build PortAudio 19.7.0 from scratch to get the fixes from https://github.com/PortAudio/portaudio/pull/504, and adjust LD_LIBRARY_PATH so that it can be loaded (fix #200)
- pre-install 2 Qt5 dependencies (xcv-xinerama and xkbcommon-x11) so that PyInstaller can correctly include them in the bundle
- update to Ubuntu bionic as the base distribution