### PR TITLE
Add an option to show estimated pitch on the spectrum.

### DIFF
--- a/friture/Spectrum.qml
+++ b/friture/Spectrum.qml
@@ -39,6 +39,13 @@ Item {
                 fmaxValue: scopedata.fmaxValue
                 fmaxLogicalValue: scopedata.fmaxLogicalValue
             }
+
+            FrequencyTracker {
+                visible: scopedata.showPitchTracker
+                anchors.fill: parent
+                fmaxValue: scopedata.fpitchDisplayText
+                fmaxLogicalValue: scopedata.fpitchValue
+            }
         }
     }
 }

--- a/friture/spectrum.py
+++ b/friture/spectrum.py
@@ -101,6 +101,14 @@ class Spectrum_Widget(QtWidgets.QWidget):
         epsilon = 1e-30
         return 10. * log10(sp + epsilon)
 
+    def harmonic_product_spectrum(self, sp):
+        # Chose 3 harmonics for no particularly good reason; initial results
+        # for pitch detection are good.
+        res = zeros(sp.shape)
+        for i in range(sp.shape[0] // 3):
+            res[i] = sp[i] * sp[i*2] * sp[i*3]
+        return res
+
     def handle_new_data(self, floatdata):
         # we need to maintain an index of where we are in the buffer
         index = self.audiobuffer.ringbuffer.offset
@@ -151,11 +159,16 @@ class Spectrum_Widget(QtWidgets.QWidget):
 
             # the log operation and the weighting could be deffered
             # to the post-weedening !
-
             i = argmax(dB_spectrogram)
             fmax = self.freq[i]
 
-            self.PlotZoneSpect.setdata(self.freq, dB_spectrogram, fmax)
+            # The maximum value in the harmonic product spectrum is quite
+            # likely to correspond to a fundamental frequency.
+            harmonic_products = self.harmonic_product_spectrum(sp1)
+            pitch_idx = argmax(harmonic_products)
+            fpitch = self.freq[pitch_idx]
+
+            self.PlotZoneSpect.setdata(self.freq, dB_spectrogram, fmax, fpitch)
 
     # method
     def canvasUpdate(self):
@@ -261,6 +274,9 @@ class Spectrum_Widget(QtWidgets.QWidget):
 
     def setShowFreqLabel(self, showFreqLabel):
         self.PlotZoneSpect.setShowFreqLabel(showFreqLabel)
+
+    def setShowPitchLabel(self, showPitchLabel):
+        self.PlotZoneSpect.setShowPitchLabel(showPitchLabel)
 
     def settings_called(self, checked):
         self.settings_dialog.show()

--- a/friture/spectrumPlotWidget.py
+++ b/friture/spectrumPlotWidget.py
@@ -73,7 +73,7 @@ class SpectrumPlotWidget(QtWidgets.QWidget):
         self.quickWidget.setResizeMode(QQuickWidget.SizeRootObjectToView)
         self.quickWidget.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
         self.quickWidget.setSource(qml_url("Spectrum.qml"))
-        
+
         raise_if_error(self.quickWidget)
 
         self.quickWidget.rootObject().setProperty("stateId", state_id)
@@ -120,6 +120,9 @@ class SpectrumPlotWidget(QtWidgets.QWidget):
     def setShowFreqLabel(self, showFreqLabel):
         self._spectrum_data.showFrequencyTracker = showFreqLabel
 
+    def setShowPitchLabel(self, showPitchLabel):
+        self._spectrum_data.showPitchTracker = showPitchLabel
+
     def set_peaks_enabled(self, enabled):
         self.peaks_enabled = enabled
 
@@ -134,13 +137,17 @@ class SpectrumPlotWidget(QtWidgets.QWidget):
     def set_baseline_dataUnits(self, baseline):
         self._baseline = Baseline.DATA_ZERO
 
-    def setdata(self, x, y, fmax):
+    def setdata(self, x, y, fmax, fpitch):
         if not self.paused:
             if fmax < 2e2:
                 text = "%.1f Hz" % (fmax)
             else:
                 text = "%d Hz" % (np.rint(fmax))
             self._spectrum_data.setFmax(text, self.normHorizontalScaleTransform.toScreen(fmax))
+            self._spectrum_data.setFpitch(
+                    f'{int(fpitch)} Hz',
+                    self.normHorizontalScaleTransform.toScreen(fpitch)
+            )
 
             M = np.max(y)
             m = self.normVerticalScaleTransform.coord_min

--- a/friture/spectrum_data.py
+++ b/friture/spectrum_data.py
@@ -24,15 +24,20 @@ from friture.scope_data import Scope_Data
 
 class Spectrum_Data(Scope_Data):
     fmax_changed = QtCore.pyqtSignal()
+    fpitch_changed = QtCore.pyqtSignal()
     show_frequency_tracker_changed = QtCore.pyqtSignal(bool)
+    show_pitch_tracker_changed = QtCore.pyqtSignal(bool)
 
     def __init__(self, parent=None):
         super().__init__(parent)
 
         self._fmax_value = ""
         self._fmax_logical_value = 0
+        self._fpitch_display = ""
+        self._fpitch_value = 0.0
         self._show_frequency_tracker = True
-    
+        self._show_pitch_tracker = True
+
     @pyqtProperty(str, notify=fmax_changed)
     def fmaxValue(self):
         return self._fmax_value
@@ -40,13 +45,27 @@ class Spectrum_Data(Scope_Data):
     @pyqtProperty(float, notify=fmax_changed)
     def fmaxLogicalValue(self):
         return self._fmax_logical_value
-    
+
     def setFmax(self, value, logical_value):
         if self._fmax_value != value or self._fmax_logical_value != logical_value:
             self._fmax_value = value
             self._fmax_logical_value = logical_value
             self.fmax_changed.emit()
-    
+
+    @pyqtProperty(str, notify=fpitch_changed)
+    def fpitchDisplayText(self):
+        return self._fpitch_display
+
+    @pyqtProperty(float, notify=fpitch_changed)
+    def fpitchValue(self):
+        return self._fpitch_value
+
+    def setFpitch(self, display_text, value):
+        if self._fpitch_display != display_text or self._fpitch_value != value:
+            self._fpitch_display = display_text
+            self._fpitch_value = value
+            self.fpitch_changed.emit()
+
     @pyqtProperty(bool, notify=show_frequency_tracker_changed)
     def showFrequencyTracker(self):
         return self._show_frequency_tracker
@@ -56,3 +75,13 @@ class Spectrum_Data(Scope_Data):
         if self._show_frequency_tracker != show_frequency_tracker:
             self._show_frequency_tracker = show_frequency_tracker
             self.show_frequency_tracker_changed.emit(show_frequency_tracker)
+
+    @pyqtProperty(bool, notify=show_pitch_tracker_changed)
+    def showPitchTracker(self):
+        return self._show_pitch_tracker
+
+    @showPitchTracker.setter
+    def showPitchTracker(self, show_pitch_tracker):
+        if self._show_pitch_tracker != show_pitch_tracker:
+            self._show_pitch_tracker = show_pitch_tracker
+            self.show_pitch_tracker_changed.emit(show_pitch_tracker)

--- a/friture/spectrum_settings.py
+++ b/friture/spectrum_settings.py
@@ -32,6 +32,7 @@ DEFAULT_SPEC_MIN = -100
 DEFAULT_SPEC_MAX = -20
 DEFAULT_WEIGHTING = 1  # A
 DEFAULT_SHOW_FREQ_LABELS = True
+DEFAULT_SHOW_PITCH_LABELS = False
 DEFAULT_RESPONSE_TIME = 0.025
 DEFAULT_RESPONSE_TIME_INDEX = 0
 
@@ -125,6 +126,10 @@ class Spectrum_Settings_Dialog(QtWidgets.QDialog):
         self.checkBox_showFreqLabels.setObjectName("showFreqLabels")
         self.checkBox_showFreqLabels.setChecked(DEFAULT_SHOW_FREQ_LABELS)
 
+        self.checkBox_showPitchLabel = QtWidgets.QCheckBox(self)
+        self.checkBox_showPitchLabel.setObjectName("showPitchLabels")
+        self.checkBox_showPitchLabel.setChecked(DEFAULT_SHOW_PITCH_LABELS)
+
         self.formLayout.addRow("Measurement type:", self.comboBox_dual_channel)
         self.formLayout.addRow("FFT Size:", self.comboBox_fftsize)
         self.formLayout.addRow("Frequency scale:", self.comboBox_freqscale)
@@ -135,6 +140,7 @@ class Spectrum_Settings_Dialog(QtWidgets.QDialog):
         self.formLayout.addRow("Middle-ear weighting:", self.comboBox_weighting)
         self.formLayout.addRow("Response time:", self.comboBox_response_time)
         self.formLayout.addRow("Display max-frequency label:", self.checkBox_showFreqLabels)
+        self.formLayout.addRow("Display pitch label:", self.checkBox_showPitchLabel)
 
         self.setLayout(self.formLayout)
 
@@ -148,6 +154,7 @@ class Spectrum_Settings_Dialog(QtWidgets.QDialog):
         self.comboBox_weighting.currentIndexChanged.connect(self.parent().setweighting)
         self.comboBox_response_time.currentIndexChanged.connect(self.responsetimechanged)
         self.checkBox_showFreqLabels.toggled.connect(self.parent().setShowFreqLabel)
+        self.checkBox_showPitchLabel.toggled.connect(self.parent().setShowPitchLabel)
 
     # slot
     def dualchannelchanged(self, index):
@@ -192,6 +199,7 @@ class Spectrum_Settings_Dialog(QtWidgets.QDialog):
         settings.setValue("weighting", self.comboBox_weighting.currentIndex())
         settings.setValue("responseTime", self.comboBox_response_time.currentIndex())
         settings.setValue("showFreqLabels", self.checkBox_showFreqLabels.isChecked())
+        settings.setValue("showPitchLabel", self.checkBox_showPitchLabel.isChecked())
 
     # method
     def restoreState(self, settings):
@@ -213,3 +221,5 @@ class Spectrum_Settings_Dialog(QtWidgets.QDialog):
         self.comboBox_response_time.setCurrentIndex(responseTime)
         showFreqLabels = settings.value("showFreqLabels", DEFAULT_SHOW_FREQ_LABELS, type=bool)
         self.checkBox_showFreqLabels.setChecked(showFreqLabels)
+        showPitchLabel = settings.value("showPitchLabel", DEFAULT_SHOW_PITCH_LABELS, type=bool)
+        self.checkBox_showPitchLabel.setChecked(showPitchLabel)


### PR DESCRIPTION
This uses a simple 3-Harmonic Product Spectrum. It works well when tested on my own voice (whereas Fmax often makes an octave error with the first overtone).