### PR TITLE
chore: update Github runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
         if-no-files-found: error
 
   build-linux:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: ['3.11']
@@ -96,7 +96,7 @@ jobs:
         if-no-files-found: error
 
   build-macos:
-    runs-on: macos-10.15
+    runs-on: macos-12
     strategy:
       matrix:
         python-version: ['3.11']


### PR DESCRIPTION
Ubuntu 18 and Macos 10 runners are obsolete