### PR TITLE
remove stray tab in spectrum_settings.py which was causing a TabError

### DIFF
--- a/friture/spectrum_settings.py
+++ b/friture/spectrum_settings.py
@@ -179,7 +179,7 @@ class Spectrum_Settings_Dialog(QtWidgets.QDialog):
             response_time = 0.3
         elif index == 3:
             response_time = 1.
-	elif index == 4:
+        elif index == 4:
             response_time = 5.            
         self.logger.info("responsetimechanged slot %d %d", index, response_time)
         self.parent().setresponsetime(response_time)


### PR DESCRIPTION
This tab was introduced by #252 and causing me build errors. This patch simply replaces the tab with spaces.