### PR TITLE
Show note names in pitch estimate and trackers

### DIFF
--- a/friture/histplot.py
+++ b/friture/histplot.py
@@ -54,7 +54,7 @@ class HistPlot(QtWidgets.QWidget):
         self._histplot_data.vertical_axis.name = "PSD (dB A)"
         self._histplot_data.vertical_axis.setTrackerFormatter(lambda x: "%.1f dB" % (x))
         self._histplot_data.horizontal_axis.name = "Frequency (Hz)"
-        self._histplot_data.horizontal_axis.setTrackerFormatter(lambda x: "%.0f Hz" % (x))
+        self._histplot_data.horizontal_axis.setTrackerFormatter(self.format_frequency)
 
         self._histplot_data.vertical_axis.setRange(0, 1)
         self._histplot_data.horizontal_axis.setRange(44, 22000)
@@ -88,6 +88,9 @@ class HistPlot(QtWidgets.QWidget):
         plotLayout.addWidget(self.quickWidget)
 
         self.setLayout(plotLayout)
+
+    def format_frequency(self, freq: float) -> str:
+        return f'{freq:.0f} Hz ({fscales.freq_to_note(freq)})'
 
     def on_status_changed(self, status):
         if status == QQuickWidget.Error:

--- a/friture/imageplot.py
+++ b/friture/imageplot.py
@@ -196,7 +196,7 @@ class ImagePlot(QtWidgets.QWidget):
         self.colorScale.setTitle("PSD (dB A)")
 
         self.canvasWidget = CanvasWidget(self, self.verticalScaleTransform, self.horizontalScaleTransform)
-        self.canvasWidget.setTrackerFormatter(lambda x, y: "%.2f s, %d Hz" % (x, y))
+        self.canvasWidget.setTrackerFormatter(self.trackerFormatter)
 
         plotLayout = QtWidgets.QGridLayout()
         plotLayout.setSpacing(0)
@@ -220,6 +220,9 @@ class ImagePlot(QtWidgets.QWidget):
 
         # need to replot here for the size Hints to be computed correctly (depending on axis scales...)
         self.update()
+
+    def trackerFormatter(self, x: float, y: float) -> str:
+        return f'{x:.2f} s, {y:.0f} Hz ({fscales.freq_to_note(y)})'
 
     def addData(self, freq, xyzs, last_data_time):
         self.plotImage.addData(freq, xyzs, self.freqscale, last_data_time)

--- a/friture/plotting/frequency_scales.py
+++ b/friture/plotting/frequency_scales.py
@@ -137,6 +137,15 @@ class Linear(object):
 
         return ticks
 
+def freq_to_note(freq: float) -> str:
+    if np.isnan(freq) or freq <= 0:
+        return ""
+    # number of semitones from C4
+    # A4 = 440Hz and is 9 semitones above C4
+    semitone = round(np.log2(freq/440) * 12) + 9
+    octave = int(np.floor(semitone / 12)) + 4
+    notes = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
+    return f'{notes[semitone % 12]}{octave}'
 
 class Logarithmic(object):
     NAME = 'Logarithmic'

--- a/friture/spectrum.py
+++ b/friture/spectrum.py
@@ -170,7 +170,7 @@ class Spectrum_Widget(QtWidgets.QWidget):
             # likely to correspond to a fundamental frequency.
             harmonic_products = self.harmonic_product_spectrum(sp1)
             pitch_idx = argmax(harmonic_products)
-            fpitch = self.freq[pitch_idx]
+            fpitch = max(self.freq[pitch_idx], 1e-20)
 
             self.PlotZoneSpect.setdata(self.freq, dB_spectrogram, fmax, fpitch)
 

--- a/friture/spectrumPlotWidget.py
+++ b/friture/spectrumPlotWidget.py
@@ -18,13 +18,15 @@ from friture.store import GetStore
 from friture.qml_tools import qml_url, raise_if_error
 
 # The peak decay rates (magic goes here :).
-PEAK_DECAY_RATE = 1.0 - 3E-6
+PEAK_DECAY_RATE = 1.0 - 3e-6
 # Number of cycles the peak stays on hold before fall-off.
 PEAK_FALLOFF_COUNT = 32  # default : 16
 
+
 class Baseline(Enum):
-    PLOT_BOTTOM = 1,
+    PLOT_BOTTOM = (1,)
     DATA_ZERO = 2
+
 
 class SpectrumPlotWidget(QtWidgets.QWidget):
 
@@ -47,7 +49,9 @@ class SpectrumPlotWidget(QtWidgets.QWidget):
         self._spectrum_data.vertical_axis.name = "PSD (dB)"
         self._spectrum_data.vertical_axis.setTrackerFormatter(lambda x: "%.1f dB" % (x))
         self._spectrum_data.horizontal_axis.name = "Frequency (Hz)"
-        self._spectrum_data.horizontal_axis.setTrackerFormatter(lambda x: "%.0f Hz" % (x))
+        self._spectrum_data.horizontal_axis.setTrackerFormatter(
+            self.trackerFormatterPitch
+        )
 
         self._spectrum_data.vertical_axis.setRange(0, 1)
         self._spectrum_data.horizontal_axis.setRange(0, 22000)
@@ -71,7 +75,9 @@ class SpectrumPlotWidget(QtWidgets.QWidget):
         self.quickWidget = QQuickWidget(engine, self)
         self.quickWidget.statusChanged.connect(self.on_status_changed)
         self.quickWidget.setResizeMode(QQuickWidget.SizeRootObjectToView)
-        self.quickWidget.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
+        self.quickWidget.setSizePolicy(
+            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding
+        )
         self.quickWidget.setSource(qml_url("Spectrum.qml"))
 
         raise_if_error(self.quickWidget)
@@ -137,17 +143,25 @@ class SpectrumPlotWidget(QtWidgets.QWidget):
     def set_baseline_dataUnits(self, baseline):
         self._baseline = Baseline.DATA_ZERO
 
-
     def freq_to_note(self, freq: float) -> str:
         if freq == 0:
             return ""
         # number of semitones from C4
         # A4 = 440Hz and is 9 semitones above C4
-        semitone = round(np.log2(freq/440) * 12) + 9
+        semitone = round(np.log2(freq / 440) * 12) + 9
         octave = int(np.floor(semitone / 12)) + 4
         notes = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
-        return f'{notes[semitone % 12]}{octave}'
+        return f"{notes[semitone % 12]}{octave}"
 
+    def trackerFormatterPitch(self, x):
+        try:
+            note = self.freq_to_note(x)
+        except ValueError:
+            return ""
+        if x < 1000:
+            return "%d Hz (%s)" % (int(x), note)
+        else:
+            return "%.1f kHz (%s)" % (x / 1000, note)
 
     def setdata(self, x, y, fmax, fpitch):
         if not self.paused:
@@ -155,36 +169,46 @@ class SpectrumPlotWidget(QtWidgets.QWidget):
                 text = "%.1f Hz" % (fmax)
             else:
                 text = "%d Hz" % (np.rint(fmax))
-            self._spectrum_data.setFmax(text, self.normHorizontalScaleTransform.toScreen(fmax))
+            self._spectrum_data.setFmax(
+                text, self.normHorizontalScaleTransform.toScreen(fmax)
+            )
             self._spectrum_data.setFpitch(
-                    f'{int(fpitch)} Hz ({self.freq_to_note(fpitch)})',
-                    self.normHorizontalScaleTransform.toScreen(fpitch)
+                f"{int(fpitch)} Hz ({self.freq_to_note(fpitch)})",
+                self.normHorizontalScaleTransform.toScreen(fpitch),
             )
 
             M = np.max(y)
             m = self.normVerticalScaleTransform.coord_min
-            y_int = (y-m)/(np.abs(M-m)+1e-3)
+            y_int = (y - m) / (np.abs(M - m) + 1e-3)
 
             x_left = zeros(x.shape)
             x_right = zeros(x.shape)
             x_left[0] = 1e-10
-            x_left[1:] = (x[1:] + x[:-1]) / 2.
+            x_left[1:] = (x[1:] + x[:-1]) / 2.0
             x_right[:-1] = x_left[1:]
             x_right[-1] = float(SAMPLING_RATE / 2)
             scaled_x_left = self.normHorizontalScaleTransform.toScreen(x_left)
             scaled_x_right = self.normHorizontalScaleTransform.toScreen(x_right)
 
-            baseline = 1. if self._baseline == Baseline.PLOT_BOTTOM else (1. - self.normVerticalScaleTransform.toScreen(0.))
+            baseline = (
+                1.0
+                if self._baseline == Baseline.PLOT_BOTTOM
+                else (1.0 - self.normVerticalScaleTransform.toScreen(0.0))
+            )
 
-            scaled_y = 1. - self.normVerticalScaleTransform.toScreen(y)
+            scaled_y = 1.0 - self.normVerticalScaleTransform.toScreen(y)
             z = y_int
-            self._curve_signal.setData(scaled_x_left, scaled_x_right, scaled_y, z, baseline)
+            self._curve_signal.setData(
+                scaled_x_left, scaled_x_right, scaled_y, z, baseline
+            )
 
             if self.peaks_enabled:
                 self.compute_peaks(y)
-                scaled_peak = 1. - self.normVerticalScaleTransform.toScreen(self.peak)
+                scaled_peak = 1.0 - self.normVerticalScaleTransform.toScreen(self.peak)
                 z_peak = self.peak_int
-                self._curve_peak.setData(scaled_x_left, scaled_x_right, scaled_peak, z_peak, baseline)
+                self._curve_peak.setData(
+                    scaled_x_left, scaled_x_right, scaled_peak, z_peak, baseline
+                )
 
     def draw(self):
         return
@@ -201,20 +225,20 @@ class SpectrumPlotWidget(QtWidgets.QWidget):
     def compute_peaks(self, y):
         if len(self.peak) != len(y):
             y_ones = ones(y.shape)
-            self.peak = y_ones * (-500.)
+            self.peak = y_ones * (-500.0)
             self.peak_int = zeros(y.shape)
-            self.peak_decay = y_ones * 20. * log10(PEAK_DECAY_RATE) * 5000
+            self.peak_decay = y_ones * 20.0 * log10(PEAK_DECAY_RATE) * 5000
 
-        mask1 = (self.peak < y)
-        mask2 = (~mask1)
+        mask1 = self.peak < y
+        mask2 = ~mask1
         mask2_a = mask2 * (self.peak_int < 0.2)
         mask2_b = mask2 * (self.peak_int >= 0.2)
 
         self.peak[mask1] = y[mask1]
         self.peak[mask2_a] = self.peak[mask2_a] + self.peak_decay[mask2_a]
 
-        self.peak_decay[mask1] = 20. * log10(PEAK_DECAY_RATE) * 5000
-        self.peak_decay[mask2_a] += 20. * log10(PEAK_DECAY_RATE) * 5000
+        self.peak_decay[mask1] = 20.0 * log10(PEAK_DECAY_RATE) * 5000
+        self.peak_decay[mask2_a] += 20.0 * log10(PEAK_DECAY_RATE) * 5000
 
-        self.peak_int[mask1] = 1.
+        self.peak_int[mask1] = 1.0
         self.peak_int[mask2_b] *= 0.975

--- a/friture/spectrumPlotWidget.py
+++ b/friture/spectrumPlotWidget.py
@@ -137,6 +137,18 @@ class SpectrumPlotWidget(QtWidgets.QWidget):
     def set_baseline_dataUnits(self, baseline):
         self._baseline = Baseline.DATA_ZERO
 
+
+    def freq_to_note(self, freq: float) -> str:
+        if freq == 0:
+            return ""
+        # number of semitones from C4
+        # A4 = 440Hz and is 9 semitones above C4
+        semitone = round(np.log2(freq/440) * 12) + 9
+        octave = int(np.floor(semitone / 12)) + 4
+        notes = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
+        return f'{notes[semitone % 12]}{octave}'
+
+
     def setdata(self, x, y, fmax, fpitch):
         if not self.paused:
             if fmax < 2e2:
@@ -145,7 +157,7 @@ class SpectrumPlotWidget(QtWidgets.QWidget):
                 text = "%d Hz" % (np.rint(fmax))
             self._spectrum_data.setFmax(text, self.normHorizontalScaleTransform.toScreen(fmax))
             self._spectrum_data.setFpitch(
-                    f'{int(fpitch)} Hz',
+                    f'{int(fpitch)} Hz ({self.freq_to_note(fpitch)})',
                     self.normHorizontalScaleTransform.toScreen(fpitch)
             )
 


### PR DESCRIPTION
This also incorporates a new frequency scale that places major ticks at the octaves of A (standard A440 tuning), and minor ticks at the intermediate minor thirds, which is quite useful when looking at plots from a pitch perspective.

I wanted to include Alexis's parallel work for contribution credit, although it does kinda make this more complicated of a change than necessary and they added a bunch of noise by (probably automatically and unintentionally) running a code formatter on spectrumPlotWidget.py :woman_shrugging: 