### PR TITLE
Make some improvements to the pitch tracker widget

### DIFF
--- a/friture/PitchView.qml
+++ b/friture/PitchView.qml
@@ -1,0 +1,58 @@
+import QtQuick 2.9
+import QtQuick.Window 2.2
+import QtQuick.Layouts 1.15
+import Friture 1.0
+
+Rectangle {
+    id: pitch
+    SystemPalette { id: myPalette; colorGroup: SystemPalette.Active }
+    color: myPalette.window
+
+    implicitWidth: pitchCol.implicitWidth
+    implicitHeight: parent ? parent.height : 0
+
+    property var pitch_view_model
+
+    ColumnLayout {
+        id: pitchCol
+        spacing: 0
+
+        FontMetrics {
+            id: fontMetrics
+            font.pointSize: 14
+            font.bold: true
+        }
+
+        Text {
+            id: note
+            text: pitch_view_model.note
+            textFormat: Text.PlainText
+            font.pointSize: 14
+            font.bold: true
+            rightPadding: 6
+            horizontalAlignment: Text.AlignRight
+            Layout.alignment: Qt.AlignTop | Qt.AlignRight
+        }
+
+        Text {
+            id: pitchHz
+            text: pitch_view_model.pitch
+            textFormat: Text.PlainText
+            font.pointSize: 14
+            font.bold: true
+            rightPadding: 6
+            horizontalAlignment: Text.AlignRight
+            Layout.preferredWidth: fontMetrics.boundingRect("000.0").width
+            Layout.alignment: Qt.AlignTop | Qt.AlignRight
+        }
+
+        Text {
+            id: pitchUnit
+            text: pitch_view_model.pitch_unit
+            textFormat: Text.PlainText
+            rightPadding: 6
+            horizontalAlignment: Text.AlignRight
+            Layout.alignment: Qt.AlignTop | Qt.AlignRight
+        }
+    }
+}

--- a/friture/PlotArea.qml
+++ b/friture/PlotArea.qml
@@ -14,12 +14,14 @@ Item {
     PlotBackground {
         anchors.fill: parent
     }
-    
+
     PlotGrid {
         anchors.fill: parent
 
         vertical_scale_division: scopePlotArea.vertical_axis.scale_division
+        show_minor_vertical: scopePlotArea.vertical_axis.show_minor_grid_lines
         horizontal_scale_division: scopePlotArea.horizontal_axis.scale_division
+        show_minor_horizontal: scopePlotArea.horizontal_axis.show_minor_grid_lines
     }
 
     Item {
@@ -43,7 +45,7 @@ Item {
 
         property double posX: Math.min(Math.max(plotMouseArea.mouseX, 0), scopePlotArea.width)
         property double posY: Math.min(Math.max(plotMouseArea.mouseY, 0), scopePlotArea.height)
-        
+
         property double relativePosX: posX / scopePlotArea.width
         property double relativePosY: posY / scopePlotArea.height
 

--- a/friture/PlotGrid.qml
+++ b/friture/PlotGrid.qml
@@ -10,11 +10,31 @@ Item {
     property color lineColor: "lightgray"
 
     required property ScaleDivision vertical_scale_division
+    property bool show_minor_vertical: false
     required property ScaleDivision horizontal_scale_division
+    property bool show_minor_horizontal: false
 
     // QML docs discourage the use of multiple Shape objects. But the Repeater cannot be used inside Shape.
     Repeater {
         model: vertical_scale_division.logicalMajorTicks
+
+        Shape {
+            y: (1. - modelData.logicalValue) * plotGrid.height
+
+            ShapePath {
+                strokeWidth: lineWidth
+                strokeColor: lineColor
+                fillColor: "transparent"
+                scale: Qt.size(plotGrid.width, 1)
+
+                PathMove { x: 0; y: 0 }
+                PathLine { x: 1; y: 0 }
+            }
+        }
+    }
+
+    Repeater {
+        model: show_minor_vertical ? vertical_scale_division.logicalMinorTicks : []
 
         Shape {
             y: (1. - modelData.logicalValue) * plotGrid.height
@@ -52,7 +72,7 @@ Item {
 
     // QML docs discourage the use of multiple Shape objects. But the Repeater cannot be used inside Shape.
     Repeater {
-        model: horizontal_scale_division.logicalMinorTicks
+        model: show_minor_horizontal ? horizontal_scale_division.logicalMinorTicks : []
 
         Shape {
             x: modelData.logicalValue * plotGrid.width

--- a/friture/axis.py
+++ b/friture/axis.py
@@ -14,21 +14,22 @@ class Axis(QtCore.QObject):
         self._formatter = lambda x: str(x)
         self._scale_division = ScaleDivision(-1., 1., self)
         self._coordinate_transform = CoordinateTransform(-1, 1, 1., 0, 0, self)
+        self._show_minor_grid_lines = False
 
     @pyqtProperty(str, notify=name_changed)
     def name(self):
         return self._name
-    
+
     @name.setter
     def name(self, name):
         if self._name != name:
             self._name = name
             self.name_changed.emit(name)
-    
+
     def setTrackerFormatter(self, formatter):
         if self._formatter != formatter:
             self._formatter = formatter
-    
+
     @pyqtSlot(float, result=str)
     def formatTracker(self, value):
         return self._formatter(value)
@@ -44,7 +45,15 @@ class Axis(QtCore.QObject):
     @pyqtProperty(ScaleDivision, constant=True)
     def scale_division(self):
         return self._scale_division
-    
+
+    @pyqtProperty(bool, constant=True)
+    def show_minor_grid_lines(self) -> bool:
+        return self._show_minor_grid_lines
+
+    @show_minor_grid_lines.setter # type: ignore
+    def show_minor_grid_lines(self, show: bool):
+        self._show_minor_grid_lines = show
+
     @pyqtProperty(CoordinateTransform, constant=True)
     def coordinate_transform(self):
         return self._coordinate_transform

--- a/friture/histplot.py
+++ b/friture/histplot.py
@@ -56,6 +56,7 @@ class HistPlot(QtWidgets.QWidget):
         self._histplot_data.vertical_axis.setTrackerFormatter(lambda x: "%.1f dB" % (x))
         self._histplot_data.horizontal_axis.name = "Frequency (Hz)"
         self._histplot_data.horizontal_axis.setTrackerFormatter(format_frequency)
+        self._histplot_data.horizontal_axis.show_minor_grid_lines = True
 
         self._histplot_data.vertical_axis.setRange(0, 1)
         self._histplot_data.horizontal_axis.setRange(44, 22000)

--- a/friture/pitch_tracker.py
+++ b/friture/pitch_tracker.py
@@ -85,6 +85,7 @@ class PitchTrackerWidget(QtWidgets.QWidget):
         self._pitch_tracker_data.vertical_axis.name = "Frequency (Hz)"
         self._pitch_tracker_data.vertical_axis.setTrackerFormatter(
             format_frequency)
+        self._pitch_tracker_data.vertical_axis.show_minor_grid_lines = True
         self._pitch_tracker_data.horizontal_axis.name = "Time (sec)"
         self._pitch_tracker_data.horizontal_axis.setTrackerFormatter(
             lambda x: "%#.3g sec" % (x))

--- a/friture/pitch_tracker_settings.py
+++ b/friture/pitch_tracker_settings.py
@@ -25,7 +25,7 @@ from friture.audiobackend import SAMPLING_RATE
 DEFAULT_MIN_FREQ = 80
 DEFAULT_MAX_FREQ = 1000
 DEFAULT_DURATION = 30
-DEFAULT_MIN_SNR = 3.0
+DEFAULT_MIN_DB = -70.0
 DEFAULT_FFT_SIZE = 16384
 
 class PitchTrackerSettingsDialog(QtWidgets.QDialog):
@@ -64,15 +64,15 @@ class PitchTrackerSettingsDialog(QtWidgets.QDialog):
         self.duration.valueChanged.connect(self.parent().set_duration)
         self.form_layout.addRow("Duration:", self.duration)
 
-        self.min_snr = QtWidgets.QDoubleSpinBox(self)
-        self.min_snr.setMinimum(0)
-        self.min_snr.setMaximum(50)
-        self.min_snr.setSingleStep(1)
-        self.min_snr.setValue(DEFAULT_MIN_SNR)
-        self.min_snr.setSuffix(" dB")
-        self.min_snr.setObjectName("min_snr")
-        self.min_snr.valueChanged.connect(self.parent().set_min_snr)
-        self.form_layout.addRow("Min SNR:", self.min_snr)
+        self.min_db = QtWidgets.QDoubleSpinBox(self)
+        self.min_db.setMinimum(-100)
+        self.min_db.setMaximum(0)
+        self.min_db.setSingleStep(1)
+        self.min_db.setValue(DEFAULT_MIN_DB)
+        self.min_db.setSuffix(" dB")
+        self.min_db.setObjectName("min_db")
+        self.min_db.valueChanged.connect(self.parent().set_min_db) # type: ignore
+        self.form_layout.addRow("Min Amplitude:", self.min_db)
 
         self.setLayout(self.form_layout)
 
@@ -80,7 +80,7 @@ class PitchTrackerSettingsDialog(QtWidgets.QDialog):
         settings.setValue("min_freq", self.min_freq.value())
         settings.setValue("max_freq", self.max_freq.value())
         settings.setValue("duration", self.duration.value())
-        settings.setValue("min_snr", self.min_snr.value())
+        settings.setValue("min_db", self.min_db.value())
 
     def restore_state(self, settings):
         self.min_freq.setValue(
@@ -89,5 +89,6 @@ class PitchTrackerSettingsDialog(QtWidgets.QDialog):
             settings.value("max_freq", DEFAULT_MAX_FREQ, type=int))
         self.duration.setValue(
             settings.value("duration", DEFAULT_DURATION, type=int))
-        self.min_snr.setValue(
-            settings.value("min_snr", DEFAULT_MIN_SNR, type=float))
+        self.min_db.setValue(
+            settings.value("min_db", DEFAULT_MIN_DB, type=float))
+

--- a/friture/spectrumPlotWidget.py
+++ b/friture/spectrumPlotWidget.py
@@ -51,6 +51,7 @@ class SpectrumPlotWidget(QtWidgets.QWidget):
         self._spectrum_data.vertical_axis.setTrackerFormatter(lambda x: "%.1f dB" % (x))
         self._spectrum_data.horizontal_axis.name = "Frequency (Hz)"
         self._spectrum_data.horizontal_axis.setTrackerFormatter(format_frequency)
+        self._spectrum_data.horizontal_axis.show_minor_grid_lines = True
 
         self._spectrum_data.vertical_axis.setRange(0, 1)
         self._spectrum_data.horizontal_axis.setRange(0, 22000)


### PR DESCRIPTION
- adds a display of the current pitch and note to the right of the graph, which is nice for controlling pitch in real time. At this point #234 seems quite fully satisfied.
- shows minor grid lines in the frequency axis, instead of time, since that's usually what one wants more precision for in this graph
- replaces minimum SNR with minimum amplitude, which is kinda crude and needs tweaking to each environment, but once tweaked generally does a good job of avoiding detecting pitches in background noise (including pitched background sounds).