### PR TITLE
Retain widget settings through switches and closes

### DIFF
--- a/friture/dockmanager.py
+++ b/friture/dockmanager.py
@@ -61,7 +61,7 @@ class DockManager(QtCore.QObject):
             widget_id = self.last_widget_stack.pop()
             settings = self.last_settings.get(widget_id)
 
-        new_dock = Dock(self.parent(), name, self._parent.qml_engine, widget_id)
+        new_dock = Dock(self._parent, name, self._parent.qml_engine, widget_id)
         if settings is not None:
             new_dock.restoreState(settings)
         #self.parent().addDockWidget(QtCore.Qt.TopDockWidgetArea, new_dock)
@@ -73,6 +73,7 @@ class DockManager(QtCore.QObject):
     def close_dock(self, dock: Dock) -> None:
         settings = QtCore.QSettings()
         dock.saveState(settings)
+        assert dock.widgetId is not None # true but mypy can't prove it
         self.last_settings[dock.widgetId] = settings
         self.last_widget_stack.append(dock.widgetId)
 


### PR DESCRIPTION
Overall, the intent is to make it more convenient to switch back and forth between widgets, or to temporarily show and then hide a widget, by not reverting widgets to default settings when doing this. More specifically:
- when a dock is closed, and then a new dock is created, the new dock will have the same widget with the same settings as previously (and this works on a stack if multiple docks are closed)
- when a dock is switched from one widget to another and then back, the initial settings will be preserved
- the above state is persisted in application settings