### PR TITLE
chore: migrate to Numpy 2

### DIFF
--- a/friture/generators/pink.py
+++ b/friture/generators/pink.py
@@ -30,7 +30,7 @@ def pinknoise(n, rvs=standard_normal):
 
     # k = int(min(np.floor(np.log(n)/np.log(2)), PINK_FIDELITY))
     k = 13  # dynamic k adds audible "clicks"
-    pink = np.zeros((n,), np.float)
+    pink = np.zeros((n,), np.float32)
 
     for m in 2 ** np.arange(k):
         p = int(np.ceil(float(n) / m))

--- a/friture/plotCurve.py
+++ b/friture/plotCurve.py
@@ -80,8 +80,8 @@ class PlotCurve(QQuickItem):
         vertices.setsize(2 * np.dtype(np.float32).itemsize * size)
 
         polygon_array = np.frombuffer(vertices, dtype=np.float32)
-        polygon_array[: (size - 1) * 2 + 1 : 2] = np.array(self.curve.x_array() * self.width(), dtype=np.float32, copy=False)
-        polygon_array[1 : (size - 1) * 2 + 2 : 2] = np.array(self.curve.y_array() * self.height(), dtype=np.float32, copy=False)
+        polygon_array[: (size - 1) * 2 + 1 : 2] = np.asarray(self.curve.x_array() * self.width(), dtype=np.float32)
+        polygon_array[1 : (size - 1) * 2 + 2 : 2] = np.asarray(self.curve.y_array() * self.height(), dtype=np.float32)
 
         paint_node.markDirty(QSGNode.DirtyGeometry)
 

--- a/friture_extensions/lfilter.pyx
+++ b/friture_extensions/lfilter.pyx
@@ -89,8 +89,8 @@ def pyx_lfilter_float64_1D(
 
     cdef Py_ssize_t len_x = x.shape[0]
     cdef Py_ssize_t len_b = b.shape[0]
-    cdef np.int_t n
-    cdef np.uint_t k
+    cdef np.intp_t n
+    cdef np.uintp_t k
 
     cdef np.ndarray[np.float64_t, ndim=1] y = np.empty(x.shape[0])
     cdef np.ndarray[np.float64_t, ndim=1] z = np.array(zi, copy=True)

--- a/friture_extensions/linear_interp.pyx
+++ b/friture_extensions/linear_interp.pyx
@@ -18,7 +18,7 @@ def pyx_linear_interp_2D(np.ndarray[dtype_t, ndim=2] resampled_buffer not None,
                          dtype_t resampling_ratio,
                          int n):
     cdef dtype_t a
-    cdef np.int_t i, j
+    cdef np.intp_t i, j
     cdef Py_ssize_t N = data.shape[0]
 
     for i in range(n):

--- a/friture_extensions/lookup_table.pyx
+++ b/friture_extensions/lookup_table.pyx
@@ -12,7 +12,7 @@ cimport cython
 
 def pyx_color_from_float(np.ndarray[np.uint32_t, ndim=1] lut not None,
                          np.ndarray[np.float64_t, ndim=1] values not None):
-    cdef np.int_t i, j
+    cdef np.intp_t i, j
     cdef Py_ssize_t N = values.shape[0]
     cdef np.ndarray[np.uint32_t, ndim=1] out = np.zeros([N], dtype=np.uint32)
 
@@ -24,7 +24,7 @@ def pyx_color_from_float(np.ndarray[np.uint32_t, ndim=1] lut not None,
 
 def pyx_color_from_float_2D(np.ndarray[np.uint32_t, ndim=1] lut not None,
                             np.ndarray[np.float64_t, ndim=2] values not None):
-    cdef np.int_t i, j, k
+    cdef np.intp_t i, j, k
     cdef Py_ssize_t M = values.shape[0]
     cdef Py_ssize_t N = values.shape[1]
     cdef np.ndarray[np.uint32_t, ndim=2] out = np.zeros([M, N], dtype=np.uint32)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools",
 
     # Cython and numpy are needed when running setup.py, to build extensions
-    "numpy==1.26.4",
+    "numpy==2.0.1",
     "Cython==3.0.10",
 ]
 build-backend = "setuptools.build_meta"
@@ -35,7 +35,7 @@ dependencies = [
     "sounddevice==0.4.5",
     "rtmixer==0.1.4",
     "docutils==0.21.2",
-    "numpy==1.26.4",
+    "numpy==2.0.1",
     "PyQt5==5.15.10",
     "appdirs==1.4.4",
     "pyrr==0.10.3",

--- a/sandbox/output.py
+++ b/sandbox/output.py
@@ -17,7 +17,7 @@ t = np.arange(0, time_s, 1./float(SAMPLING_RATE))
 
 def pinknoise(n, rvs=stats.norm.rvs):
     k = min(int(np.floor(np.log(n)/np.log(2))), 12)
-    pink = np.zeros((n,), np.float)
+    pink = np.zeros((n,), np.float32)
 
     for m in 2**np.arange(k):
         p = int(np.ceil(float(n) / m))

--- a/sandbox/pink2.py
+++ b/sandbox/pink2.py
@@ -20,7 +20,7 @@ from scipy import stats
 
 def pink1d(n, rvs=stats.norm.rvs):
     k = min(int(np.floor(np.log(n)/np.log(2))), 12)
-    pink = np.zeros((n,), np.float)
+    pink = np.zeros((n,), np.float32)
     m = 1
     for i in range(k):
         p = int(np.ceil(float(n) / m))


### PR DESCRIPTION
Numpy 2 has a couple of breaking changes. The adjustments here have been tested manually, in addition to having 'pip install .' working well (to test compiling Cython extensions).

Fixes #280