### PR TITLE
chore(deps): update PyInstaller + packaging fixes

### DIFF
--- a/.github/workflows/install-linux.sh
+++ b/.github/workflows/install-linux.sh
@@ -34,7 +34,7 @@ make install
 ls -laR portaudio-install
 cd ..
 
-pip3 install -U pyinstaller==5.7.0
+pip3 install -U pyinstaller==6.9.0
 
 pyinstaller friture.spec -y --log-level=DEBUG
 

--- a/.github/workflows/install-macos.sh
+++ b/.github/workflows/install-macos.sh
@@ -15,7 +15,7 @@ python3 setup.py build_ext --inplace
 # see: https://github.com/tlecomte/friture/issues/154
 brew install portaudio --HEAD
 
-pip3 install -U pyinstaller==5.7.0
+pip3 install -U pyinstaller==6.9.0
 
 pyinstaller friture.spec -y
 

--- a/.github/workflows/install-macos.sh
+++ b/.github/workflows/install-macos.sh
@@ -24,7 +24,7 @@ ls -la dist/*
 # compare the portaudio libs to make sure the package contains the one that was installed with brew
 ls -la /usr/local/lib/libportaudio.dylib
 ls -la /usr/local/Cellar/portaudio/*/lib/libportaudio*.dylib
-ls -la dist/friture.app/Contents/MacOS/_sounddevice_data/portaudio-binaries
+ls -la dist/friture.app/Contents/Frameworks/_sounddevice_data/portaudio-binaries
 
 # PyInstaller will try to codesign friture.app, but will fail because of the Qt5 file structure
 # (this is visible in the logs)

--- a/.github/workflows/install-windows.ps1
+++ b/.github/workflows/install-windows.ps1
@@ -85,7 +85,7 @@ Write-Host "==========================================="
 Write-Host "Installing pyinstaller"
 Write-Host "==========================================="
 
-& pip install -U pyinstaller==5.7.0
+& pip install -U pyinstaller==6.9.0
 
 Write-Host ""
 Write-Host "==========================================="

--- a/.github/workflows/install-windows.ps1
+++ b/.github/workflows/install-windows.ps1
@@ -103,17 +103,6 @@ Write-Host "==========================================="
 
 Write-Host ""
 Write-Host "==========================================="
-Write-Host "Replace icudt53.dll with smaller version"
-Write-Host "==========================================="
-
-# icudt53.dll is huge but needed for Qt
-# A stripped down version is available here:
-# https://forum.qt.io/topic/37891/minimal-icudt51-dll-icudt52-dll-and-icudt53-dll
-# http://qlcplus.sourceforge.net/icudt53.dll
-Copy-Item -Path "installer\icudt53.dll" -Destination "dist\friture\icudt53.dll"
-
-Write-Host ""
-Write-Host "==========================================="
 Write-Host "Archiving the package as a zip file"
 Write-Host "==========================================="
 

--- a/friture.spec
+++ b/friture.spec
@@ -82,7 +82,7 @@ if platform.system() == "Windows":
 a = Analysis(['main.py'],
              pathex=pathex,
              binaries=[],
-             datas= [('friture/*.qml', '.' ), ('friture/*.js', '.' )],
+             datas= [('friture/*.qml', '.' ), ('friture/playback/*.qml', 'playback' ), ('friture/*.js', '.' )],
              hiddenimports=[],
              hookspath=["installer/pyinstaller-hooks"], # our custom hooks for python-sounddevice
              runtime_hooks=[],


### PR DESCRIPTION
PyInstaller 5.12+ should fix an error with Python 3.11.4+, so we upgrade to latest.

See https://github.com/pyinstaller/pyinstaller/pull/7694

Apply some packaging fixes:
- the playback control dll needed to be added in pyinstaller data files, since it's not in the root folder
- fix a path for Macos following a breaking change in the app structure with PyInstaller 6.0+
- remove icu dll on windows, it's apparently not included anymore