### PR TITLE
Right clicking on spectrogram or pitch graph sets playback position

### DIFF
--- a/friture/Plot.qml
+++ b/friture/Plot.qml
@@ -14,6 +14,8 @@ Rectangle {
     required property ScopeData scopedata
     default property alias content: plotItemPlaceholder.children
 
+    signal pointSelected(real x, real y)
+
     GridLayout {
         anchors.fill: parent
         rowSpacing: 2
@@ -68,6 +70,8 @@ Rectangle {
                 id: plotItemPlaceholder
                 anchors.fill: parent
             }
+
+            onPointSelected: (x, y) => plot.pointSelected(x, y)
         }
 
         Item {

--- a/friture/PlotArea.qml
+++ b/friture/PlotArea.qml
@@ -11,6 +11,8 @@ Item {
 
     default property alias content: plotItemPlaceholder.children
 
+    signal pointSelected(real x, real y)
+
     PlotBackground {
         anchors.fill: parent
     }
@@ -40,7 +42,7 @@ Item {
     Item
     {
         id: crosshair
-        visible: plotMouseArea.pressed
+        visible: plotMouseArea.pressed && plotMouseArea.pressedButtons & Qt.LeftButton
         anchors.fill: parent
 
         property double posX: Math.min(Math.max(plotMouseArea.mouseX, 0), scopePlotArea.width)
@@ -83,6 +85,18 @@ Item {
     MouseArea {
         id: plotMouseArea
         anchors.fill: parent
+        acceptedButtons: Qt.LeftButton | Qt.RightButton
         cursorShape: Qt.CrossCursor
+
+        onClicked: (event) => {
+            if (event.button == Qt.RightButton) {
+                scopePlotArea.pointSelected(
+                    scopePlotArea.horizontal_axis.coordinate_transform.toPlot(
+                        crosshair.relativePosX),
+                    scopePlotArea.vertical_axis.coordinate_transform.toPlot(
+                        1. - crosshair.relativePosY)
+                );
+            }
+        }
     }
 }

--- a/friture/Scope.qml
+++ b/friture/Scope.qml
@@ -9,6 +9,8 @@ Item {
     id: container
     property var stateId
 
+    signal pointSelected(real x, real y)
+
     // delay the load of the Plot until stateId has been set
     Loader {
         id: loader
@@ -34,6 +36,8 @@ Item {
                     curve: modelData
                 }
             }
+
+            onPointSelected: (x, y) => container.pointSelected(x, y)
         }
     }
 }

--- a/friture/dock.py
+++ b/friture/dock.py
@@ -27,6 +27,7 @@ from typing import Dict, List, Optional, TYPE_CHECKING
 if TYPE_CHECKING:
     from friture.analyzer import Friture
     from friture.dockmanager import DockManager
+    from friture.playback.control import PlaybackControlWidget
     from PyQt5.QtQml import QQmlEngine
 
 
@@ -43,6 +44,7 @@ class Dock(QtWidgets.QWidget):
 
         self.dockmanager: 'DockManager' = parent.dockmanager
         self.audiobuffer = parent.audiobuffer
+        self.playback_widget: 'PlaybackControlWidget' = parent.playback_widget
 
         self.setObjectName(name)
 
@@ -108,6 +110,10 @@ class Dock(QtWidgets.QWidget):
         else:
             self.audiowidget = constructor(self)
         assert self.audiowidget is not None # mypy can't prove this :(
+
+        if hasattr(self.audiowidget, 'connect_time_selected'):
+            self.audiowidget.connect_time_selected(
+                self.playback_widget.on_time_selected)
 
         # audiowidget is duck typed for this:
         self.audiowidget.set_buffer(self.audiobuffer) # type: ignore

--- a/friture/playback/control.py
+++ b/friture/playback/control.py
@@ -93,7 +93,15 @@ class PlaybackControlWidget(QWidget):
         self.root.setPlaybackPosition(self.player.play_start_time)
 
     def on_playback_position_changed(self, value: float) -> None:
+        # This handles changes in the slider
         self.player.play_start_time = value
+
+    def on_time_selected(self, time: float) -> None:
+        # This handles clicks on plot widgets, i.e. the slider also needs
+        # to be updated.
+        time = max(time, -self.player.recorded_len_sec)
+        self.root.setPlaybackPosition(time)
+        self.on_playback_position_changed(time)
 
     def on_recorded_len_changed(self, length: float) -> None:
         # Always give the slider a nonzero length even if nothing is recorded

--- a/friture/playback/player.py
+++ b/friture/playback/player.py
@@ -97,7 +97,11 @@ class Player(QObject):
             self.recorded_len + data.shape[1], self.history_samples)
         if new_len != self.recorded_len:
             self.recorded_len = new_len
-            self.recorded_length_changed.emit(self.recorded_len / SAMPLING_RATE)
+            self.recorded_length_changed.emit(self.recorded_len_sec)
+
+    @property
+    def recorded_len_sec(self) -> float:
+        return self.recorded_len / SAMPLING_RATE
 
     def play(self) -> None:
         if self.state != PlayState.STOPPED:

--- a/friture/plotting/canvasWidget.py
+++ b/friture/plotting/canvasWidget.py
@@ -25,6 +25,7 @@ from .grid import Grid
 class CanvasWidget(QtWidgets.QWidget):
 
     resized = QtCore.pyqtSignal(int, int)
+    point_selected = QtCore.pyqtSignal(float, float)
 
     def __init__(self, parent, verticalScaleTransform, horizontalScaleTransform):
         super(CanvasWidget, self).__init__(parent)
@@ -169,6 +170,11 @@ class CanvasWidget(QtWidgets.QWidget):
         self.ruler = False
         # ask for update so the the ruler is actually erased
         self.update()
+        if event.button() == QtCore.Qt.RightButton:
+            self.point_selected.emit(
+                self.horizontalScaleTransform.toPlot(event.x()),
+                self.verticalScaleTransform.toPlot(float(self.height() - event.y()))
+            )
 
     def mouseMoveEvent(self, event):
         if event.buttons() & QtCore.Qt.LeftButton:


### PR DESCRIPTION
This makes it quite easy to select a specific recently recorded sound to play back.

I chose right click because it's unused and wouldn't interact with the existing left-click behaviour. I'm kind of on the fence on what the best UX would be here - it is a little odd for right click to do this. Left-click-to-select seems more intuitive, but then either both the tooltip and the position selection are done at once, or the tooltip needs to move. :woman_shrugging: 