### PR TITLE
feat(ui): use palette colors to support dark theme

### DIFF
--- a/friture/FrequencyTracker.qml
+++ b/friture/FrequencyTracker.qml
@@ -5,6 +5,8 @@ import Friture 1.0
 Item {
     id: frequencyTracker
 
+    SystemPalette { id: systemPalette; colorGroup: SystemPalette.Active }
+
     required property string fmaxValue
     required property string fmaxLogicalValue
 
@@ -24,11 +26,12 @@ Item {
             id: background
             width: frequencyTrackerText.contentWidth
             height: frequencyTrackerText.contentHeight
-            color: "white"
+            color: systemPalette.base
 
             Text {
                 id: frequencyTrackerText
                 text: frequencyTracker.fmaxValue
+                color: systemPalette.windowText
             }
         }
 
@@ -38,7 +41,7 @@ Item {
 
             ShapePath {
                 strokeWidth: 0
-                fillColor: "white"
+                fillColor: systemPalette.base
 
                 // draw a small downward-pointing triangle to indicate the frequency
                 PathMove { x: background.width / 2 - outline.triangleSize; y: 0 }
@@ -49,8 +52,8 @@ Item {
             ShapePath {
                 id: outline
                 strokeWidth: 1
-                strokeColor: "black"
-                fillColor: "white"
+                strokeColor: systemPalette.windowText
+                fillColor: systemPalette.base
 
                 property int triangleSize: 4
 

--- a/friture/HistPlot.qml
+++ b/friture/HistPlot.qml
@@ -9,6 +9,8 @@ Item {
     id: container
     property var stateId
 
+    SystemPalette { id: systemPalette; colorGroup: SystemPalette.Active }
+
     // delay the load of the Plot until stateId has been set
     Loader {
         id: loader
@@ -61,7 +63,7 @@ Item {
                             rotation: 270
                             transformOrigin: Item.Center
                             anchors.centerIn: parent
-                            color: modelData.y * parent.parent.height + 4 > parent.parent.height - barLabel.width - 4 ? "black" : "white"
+                            color: modelData.y * parent.parent.height + 4 > parent.parent.height - barLabel.width - 4 ? systemPalette.windowText : systemPalette.base
                         }
                     }               
                 }

--- a/friture/HorizontalScale.qml
+++ b/friture/HorizontalScale.qml
@@ -7,6 +7,8 @@ import Friture 1.0
 Item {
     id: xscaleColumn
 
+    SystemPalette { id: systemPalette; colorGroup: SystemPalette.Active }
+
     implicitHeight: childrenRect.height
 
     required property ScaleDivision scale_division
@@ -39,7 +41,7 @@ Item {
 
         ShapePath {
             strokeWidth: 1
-            strokeColor: "black"
+            strokeColor: systemPalette.windowText
             fillColor: "transparent"
 
             PathMove { x: 0; y: 0 }
@@ -59,7 +61,7 @@ Item {
             Shape {
                 ShapePath {
                     strokeWidth: 1
-                    strokeColor: "black"
+                    strokeColor: systemPalette.windowText
                     fillColor: "transparent"
 
                     PathMove { x: 0; y: 0 }
@@ -74,6 +76,7 @@ Item {
                 horizontalAlignment: Text.AlignHCenter
                 verticalAlignment: Text.AlignTop
                 y: majorTickLength + 1
+                color: systemPalette.windowText
             }
         }
     }
@@ -89,7 +92,7 @@ Item {
             Shape {
                 ShapePath {
                     strokeWidth: 1
-                    strokeColor: "black"
+                    strokeColor: systemPalette.windowText
                     fillColor: "transparent"
 
                     PathMove { x: 0; y: 0 }

--- a/friture/Legend.qml
+++ b/friture/Legend.qml
@@ -4,6 +4,8 @@ import Friture 1.0
 import "plotItemColors.js" as PlotItemColors
 
 Item {
+    SystemPalette { id: systemPalette; colorGroup: SystemPalette.Active }
+
     required property ScopeData scopedata
 
     implicitWidth: childrenRect.width
@@ -31,6 +33,7 @@ Item {
                 Text {
                     id: curve1legend
                     text: modelData.name
+                    color: systemPalette.windowText
                 }
             }
         }

--- a/friture/Levels.qml
+++ b/friture/Levels.qml
@@ -5,8 +5,8 @@ import Friture 1.0
 
 Rectangle {
     id: levels
-    SystemPalette { id: myPalette; colorGroup: SystemPalette.Active }
-    color: myPalette.window
+    SystemPalette { id: systemPalette; colorGroup: SystemPalette.Active }
+    color: systemPalette.window
 
     property var stateId
     property LevelViewModel level_view_model: Store.dock_states[stateId]  
@@ -41,6 +41,7 @@ Rectangle {
             verticalAlignment: Text.AlignBottom
             horizontalAlignment: Text.AlignRight
             Layout.alignment: Qt.AlignBottom | Qt.AlignRight
+            color: systemPalette.windowText
         }
 
         Text {
@@ -50,6 +51,7 @@ Rectangle {
             verticalAlignment: Text.AlignTop
             horizontalAlignment: Text.AlignRight
             Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
+            color: systemPalette.windowText
         }
 
         Text {
@@ -61,6 +63,7 @@ Rectangle {
             verticalAlignment: Text.AlignBottom
             horizontalAlignment: Text.AlignRight
             Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
+            color: systemPalette.windowText
         }
 
         Text {
@@ -70,6 +73,7 @@ Rectangle {
             verticalAlignment: Text.AlignTop
             horizontalAlignment: Text.AlignRight
             Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
+            color: systemPalette.windowText
         }
 
         LevelsMeter {

--- a/friture/LevelsMeter.qml
+++ b/friture/LevelsMeter.qml
@@ -4,8 +4,8 @@ import QtQuick.Layouts 1.15
 import Friture 1.0
 
 Rectangle {
-    SystemPalette { id: myPalette; colorGroup: SystemPalette.Active }
-    color: myPalette.window
+    SystemPalette { id: systemPalette; colorGroup: SystemPalette.Active }
+    color: systemPalette.window
 
     required property LevelViewModel level_view_model
 

--- a/friture/MeterScale.qml
+++ b/friture/MeterScale.qml
@@ -6,6 +6,7 @@ import "iec.js" as IECFunctions
 Item {
     id: meterScale
     implicitWidth: 16
+    SystemPalette { id: systemPalette; colorGroup: SystemPalette.Active }
 
     required property int topOffset
     required property bool twoChannels
@@ -35,7 +36,7 @@ Item {
             Shape {
                 ShapePath {
                     strokeWidth: 1
-                    strokeColor: "black"
+                    strokeColor: systemPalette.windowText
                     startX: 0
                     startY: 0
                     PathLine { x: 2; y: 0 }
@@ -51,6 +52,7 @@ Item {
                 height: 10
                 verticalAlignment: Text.AlignVCenter
                 horizontalAlignment: Text.AlignHCenter
+                color: systemPalette.windowText
             }
 
             Shape {
@@ -58,7 +60,7 @@ Item {
 
                 ShapePath {
                     strokeWidth: 1
-                    strokeColor: "black"
+                    strokeColor: systemPalette.windowText
                     startX: 14
                     startY: 0
                     PathLine { x: 16; y: 0 }

--- a/friture/PitchView.qml
+++ b/friture/PitchView.qml
@@ -5,8 +5,8 @@ import Friture 1.0
 
 Rectangle {
     id: pitch
-    SystemPalette { id: myPalette; colorGroup: SystemPalette.Active }
-    color: myPalette.window
+    SystemPalette { id: systemPalette; colorGroup: SystemPalette.Active }
+    color: systemPalette.window
 
     implicitWidth: pitchCol.implicitWidth
     implicitHeight: parent ? parent.height : 0
@@ -32,6 +32,7 @@ Rectangle {
             rightPadding: 6
             horizontalAlignment: Text.AlignRight
             Layout.alignment: Qt.AlignTop | Qt.AlignRight
+            color: systemPalette.windowText
         }
 
         Text {
@@ -44,6 +45,7 @@ Rectangle {
             horizontalAlignment: Text.AlignRight
             Layout.preferredWidth: fontMetrics.boundingRect("000.0").width
             Layout.alignment: Qt.AlignTop | Qt.AlignRight
+            color: systemPalette.windowText
         }
 
         Text {
@@ -53,6 +55,7 @@ Rectangle {
             rightPadding: 6
             horizontalAlignment: Text.AlignRight
             Layout.alignment: Qt.AlignTop | Qt.AlignRight
+            color: systemPalette.windowText
         }
     }
 }

--- a/friture/Plot.qml
+++ b/friture/Plot.qml
@@ -8,8 +8,8 @@ Rectangle {
     id: plot
     anchors.fill: parent
 
-    SystemPalette { id: myPalette; colorGroup: SystemPalette.Active }
-    color: myPalette.window
+    SystemPalette { id: systemPalette; colorGroup: SystemPalette.Active }
+    color: systemPalette.window
 
     required property ScopeData scopedata
     default property alias content: plotItemPlaceholder.children
@@ -43,6 +43,7 @@ Rectangle {
                 transformOrigin: Item.Center
                 rotation: -90
                 anchors.centerIn: parent
+                color: systemPalette.windowText
             }
         }
 
@@ -104,6 +105,7 @@ Rectangle {
             text: scopedata.horizontal_axis.name
             horizontalAlignment: Text.AlignHCenter
             Layout.fillWidth: true
+            color: systemPalette.windowText
         }
     }
 }

--- a/friture/PlotArea.qml
+++ b/friture/PlotArea.qml
@@ -6,6 +6,8 @@ import Friture 1.0
 Item {
     id: scopePlotArea
 
+    SystemPalette { id: systemPalette; colorGroup: SystemPalette.Active }
+
     required property Axis vertical_axis
     required property Axis horizontal_axis
 
@@ -32,7 +34,7 @@ Item {
     Rectangle {
         id: plotBorder
         anchors.fill: parent
-        border.color: "gray"
+        border.color: systemPalette.mid
         border.width: 1
         color: "transparent"
     }
@@ -55,7 +57,7 @@ Item {
             y: Math.max(crosshair.posY - mouseText.contentHeight - 4, 0)
             implicitWidth: mouseText.contentWidth
             implicitHeight: mouseText.contentHeight
-            color: "white"
+            color: systemPalette.base
 
             Text {
                 id: mouseText
@@ -64,13 +66,14 @@ Item {
                 property double dataY: scopePlotArea.vertical_axis.coordinate_transform.toPlot(1. - crosshair.relativePosY)
 
                 text: scopePlotArea.horizontal_axis.formatTracker(dataX)  + ", " + scopePlotArea.vertical_axis.formatTracker(dataY)
+                color: systemPalette.windowText
             }
         }
 
         Shape {
             ShapePath {
                 strokeWidth: 1
-                strokeColor: "lightgray"
+                strokeColor: systemPalette.windowText
                 fillColor: "transparent"
                 PathMove { x: crosshair.posX; y: 0 }
                 PathLine { x: crosshair.posX; y: scopePlotArea.height }

--- a/friture/PlotBackground.qml
+++ b/friture/PlotBackground.qml
@@ -5,8 +5,10 @@ import QtQuick.Shapes 1.15
 Rectangle {
     id: background
 
+    SystemPalette { id: systemPalette; colorGroup: SystemPalette.Active }
+
     gradient: Gradient {
-        GradientStop { position: 0.0; color: "#E0E0E0" }
-        GradientStop { position: 0.5; color: "white" }
+        GradientStop { position: -0.5; color: systemPalette.window }
+        GradientStop { position: 0.5; color: systemPalette.base }
     }
 }

--- a/friture/PlotGrid.qml
+++ b/friture/PlotGrid.qml
@@ -6,8 +6,10 @@ import Friture 1.0
 Item {
     id: plotGrid
 
+    SystemPalette { id: systemPalette; colorGroup: SystemPalette.Active }
+
     property double lineWidth: 1
-    property color lineColor: "lightgray"
+    property color lineColor: systemPalette.button
 
     required property ScaleDivision vertical_scale_division
     property bool show_minor_vertical: false

--- a/friture/VerticalScale.qml
+++ b/friture/VerticalScale.qml
@@ -7,6 +7,8 @@ import Friture 1.0
 Item {
     id: yscaleColumn
 
+    SystemPalette { id: systemPalette; colorGroup: SystemPalette.Active }
+
     required property ScaleDivision scale_division
 
     readonly property int majorTickLength: 8
@@ -38,7 +40,7 @@ Item {
 
         ShapePath {
             strokeWidth: 1
-            strokeColor: "black"
+            strokeColor: systemPalette.windowText
             fillColor: "transparent"
 
             PathMove { x: 0; y: 0 }
@@ -61,7 +63,7 @@ Item {
 
                 ShapePath {
                     strokeWidth: 1
-                    strokeColor: "black"
+                    strokeColor: systemPalette.windowText
                     fillColor: "transparent"
 
                     PathMove { x: 0; y: 0 }
@@ -89,6 +91,7 @@ Item {
                     anchors.right: parent.right
                     verticalAlignment: Text.AlignVCenter
                     horizontalAlignment: Text.AlignRight
+                    color: systemPalette.windowText
                 }
             }
         }
@@ -107,7 +110,7 @@ Item {
 
                 ShapePath {
                     strokeWidth: 1
-                    strokeColor: "black"
+                    strokeColor: systemPalette.windowText
                     fillColor: "transparent"
 
                     PathMove { x: 0; y: 0 }

--- a/friture/plotting/canvasWidget.py
+++ b/friture/plotting/canvasWidget.py
@@ -124,10 +124,10 @@ class CanvasWidget(QtWidgets.QWidget):
 
             # draw a white background
             painter.setPen(QtCore.Qt.NoPen)
-            painter.setBrush(QtCore.Qt.white)
+            painter.setBrush(self.palette().color(QtGui.QPalette.Base))
             painter.drawRect(rect)
 
-            painter.setPen(QtCore.Qt.black)
+            painter.setPen(self.palette().color(QtGui.QPalette.WindowText))
             painter.drawText(rect, QtCore.Qt.AlignLeft, text)
 
     def drawBackground(self, painter):
@@ -153,7 +153,7 @@ class CanvasWidget(QtWidgets.QWidget):
         if self.ruler:
             w = self.width()
             h = self.height()
-            painter.setPen(QtGui.QPen(QtGui.QColor(QtCore.Qt.black)))
+            painter.setPen(QtGui.QPen(QtGui.QColor(QtCore.Qt.white)))
             painter.drawLine(self.mousex, 0, self.mousex, h)
             painter.drawLine(0, self.mousey, w, self.mousey)
 

--- a/friture/statisticswidget.py
+++ b/friture/statisticswidget.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Friture.  If not, see <http://www.gnu.org/licenses/>.
 
-from PyQt5 import QtCore, QtWidgets
+from PyQt5 import QtCore, QtWidgets, QtGui
 from friture.audiobackend import AudioBackend
 
 
@@ -35,8 +35,12 @@ class StatisticsWidget(QtWidgets.QWidget):
 
         self.scrollAreaWidgetContents = QtWidgets.QWidget(self.stats_scrollarea)
         self.scrollAreaWidgetContents.setGeometry(QtCore.QRect(0, 0, 87, 220))
-        self.scrollAreaWidgetContents.setStyleSheet("""QWidget { background: white }""")
         self.scrollAreaWidgetContents.setObjectName("stats_scrollAreaWidgetContents")
+
+        palette = self.scrollAreaWidgetContents.palette()
+        palette.setColor(QtGui.QPalette.Window, palette.color(QtGui.QPalette.Base))
+        self.scrollAreaWidgetContents.setPalette(palette)
+        self.scrollAreaWidgetContents.setAutoFillBackground(True)
 
         self.LabelStats = QtWidgets.QLabel(self.scrollAreaWidgetContents)
         self.LabelStats.setAlignment(QtCore.Qt.AlignLeading | QtCore.Qt.AlignLeft | QtCore.Qt.AlignTop)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ Issues = "https://github.com/tlecomte/friture/issues"
 [tool.setuptools]
 packages=[
     "friture",
+    "friture.playback",
     "friture.plotting",
     "friture.generators",
     "friture.signal",


### PR DESCRIPTION
Instead of hard-coding colors, we refer the system palette. This allows to support dark themes, and even switch dynamically while Friture is running.

<img width="1111" alt="friture-dark" src="https://github.com/user-attachments/assets/74800acf-f985-4bf8-9099-ab223a9336a6">
