### PR TITLE
SPL spectrum and microphone calibration files

### DIFF
--- a/friture/Levels.qml
+++ b/friture/Levels.qml
@@ -75,6 +75,28 @@ Rectangle {
             Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
             color: systemPalette.windowText
         }
+		
+		Text {
+            id: splValues
+            textFormat: Text.MarkdownText
+            text: level_view_model.two_channels ? "1: " + level_to_text(level_view_model.level_data_slow.level_spl) + "<br />2: " + level_to_text(level_view_model.level_data_slow_2.level_spl) : level_to_text(level_view_model.level_data_slow.level_spl)
+            font.pointSize: 14
+            font.bold: true
+            verticalAlignment: Text.AlignBottom
+            horizontalAlignment: Text.AlignRight
+            Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
+            color: systemPalette.windowText
+        }
+
+        Text {
+            id: splLegend
+            textFormat: Text.PlainText
+            text: "dB SPL"
+            verticalAlignment: Text.AlignTop
+            horizontalAlignment: Text.AlignRight
+            Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
+            color: systemPalette.windowText
+        }
 
         LevelsMeter {
             Layout.fillHeight: true

--- a/friture/SPL.qml
+++ b/friture/SPL.qml
@@ -1,0 +1,57 @@
+import QtQuick 2.15
+import QtQuick.Window 2.2
+import QtQuick.Layouts 1.15
+import QtQuick.Shapes 1.15
+import Friture 1.0
+
+Item {
+    id: container
+    property var stateId
+
+    // delay the load of the Plot until stateId has been set
+    Loader {
+        id: loader
+        anchors.fill: parent
+    }
+
+    onStateIdChanged: {
+        console.log("stateId changed: " + stateId)
+        loader.sourceComponent = plotComponent
+    }
+
+    Component {
+        id: plotComponent
+        Plot {
+            scopedata: Store.dock_states[container.stateId]
+
+            Repeater {
+                model: scopedata.plot_items
+
+                PlotFilledCurve {
+                    anchors.fill: parent
+                    curve: modelData
+                }
+            }
+
+            Column {
+                anchors.fill: parent
+                spacing: 0
+                FrequencyTracker {
+                    visible: scopedata.showFrequencyTracker
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    fmaxValue: scopedata.fmaxValue
+                    fmaxLogicalValue: scopedata.fmaxLogicalValue
+                }
+
+                FrequencyTracker {
+                    visible: scopedata.showPitchTracker
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    fmaxValue: scopedata.fpitchDisplayText
+                    fmaxLogicalValue: scopedata.fpitchValue
+                }
+            }
+        }
+    }
+}

--- a/friture/analyzer.py
+++ b/friture/analyzer.py
@@ -58,6 +58,7 @@ from friture.plotting.scaleDivision import ScaleDivision, Tick
 from friture.spectrogram_item import SpectrogramItem
 from friture.spectrogram_item_data import SpectrogramImageData
 from friture.spectrum_data import Spectrum_Data
+from friture.spl_data import SPLData
 from friture.plotFilledCurve import PlotFilledCurve
 from friture.filled_curve import FilledCurve
 from friture.qml_tools import qml_url
@@ -98,6 +99,7 @@ class Friture(QMainWindow, ):
         qmlRegisterType(CoordinateTransform, 'Friture', 1, 0, 'CoordinateTransform')
         qmlRegisterType(Scope_Data, 'Friture', 1, 0, 'ScopeData')
         qmlRegisterType(Spectrum_Data, 'Friture', 1, 0, 'SpectrumData')
+        qmlRegisterType(SPLData, 'Friture', 1, 0, 'SPLData')
         qmlRegisterType(LevelData, 'Friture', 1, 0, 'LevelData')
         qmlRegisterType(LevelViewModel, 'Friture', 1, 0, 'LevelViewModel')
         qmlRegisterType(Axis, 'Friture', 1, 0, 'Axis')

--- a/friture/analyzer.py
+++ b/friture/analyzer.py
@@ -45,6 +45,7 @@ from friture.tilelayout import TileLayout
 from friture.level_view_model import LevelViewModel
 from friture.level_data import LevelData
 from friture.levels import Levels_Widget
+from friture.octavespectrum import OctaveSpectrum_Widget
 from friture.store import GetStore, Store
 from friture.scope_data import Scope_Data
 from friture.axis import Axis
@@ -112,6 +113,9 @@ class Friture(QMainWindow, ):
         qmlRegisterType(ColorBar, 'Friture', 1, 0, 'ColorBar')
         qmlRegisterType(Tick, 'Friture', 1, 0, 'Tick')
         qmlRegisterSingletonType(Store, 'Friture', 1, 0, 'Store', lambda engine, script_engine: GetStore())
+        
+        self.original_calibration = [0, 0]
+        self.original_calibration_freqs = [0, 20000]
 
         # Setup the user interface
         self.ui = Ui_MainWindow()
@@ -312,6 +316,14 @@ class Friture(QMainWindow, ):
             self.playback_widget.start_recording()
             AudioBackend().restart()
             self.dockmanager.restart()
+    
+    def recalculate_calibration(self):
+        for dock in self.dockmanager.docks:
+            if not dock.audiowidget is None:
+                if hasattr(dock.audiowidget, "proc"):
+                    dock.audiowidget.proc.recalculate_calibration()
+                elif type(dock.audiowidget) == OctaveSpectrum_Widget:
+                    dock.audiowidget.filters.recalculate_calibration()
 
 
 def qt_message_handler(mode, context, message):

--- a/friture/level_data.py
+++ b/friture/level_data.py
@@ -24,12 +24,14 @@ from friture.iec import dB_to_IEC
 
 class LevelData(QtCore.QObject):
     level_rms_changed = QtCore.pyqtSignal(float)
+    level_spl_changed = QtCore.pyqtSignal(float)
     level_max_changed = QtCore.pyqtSignal(float)
 
     def __init__(self, parent=None):
         super().__init__(parent)
 
         self._level_rms = -30.
+        self._level_spl = -30.
         self._level_max = -30.
 
     @pyqtProperty(float, notify=level_rms_changed) # type: ignore
@@ -45,6 +47,20 @@ class LevelData(QtCore.QObject):
         if self._level_rms != level_rms:
             self._level_rms = level_rms
             self.level_rms_changed.emit(level_rms)
+
+    @pyqtProperty(float, notify=level_spl_changed) # type: ignore
+    def level_spl(self):
+        return self._level_spl
+
+    @pyqtProperty(float, notify=level_spl_changed) # type: ignore
+    def level_spl_iec(self):
+        return dB_to_IEC(self._level_spl)
+
+    @level_spl.setter # type: ignore
+    def level_spl(self, level_spl):
+        if self._level_spl != level_spl:
+            self._level_spl = level_spl
+            self.level_spl_changed.emit(level_spl)
 
     @pyqtProperty(float, notify=level_max_changed) # type: ignore
     def level_max(self):

--- a/friture/levels.py
+++ b/friture/levels.py
@@ -33,6 +33,8 @@ from friture_extensions.exp_smoothing_conv import pyx_exp_smoothed_value
 from friture.audiobackend import SAMPLING_RATE
 from friture.qml_tools import qml_url, raise_if_error
 
+from friture.spl_settings import SPL_Settings_Dialog
+
 SMOOTH_DISPLAY_TIMER_PERIOD_MS = 25
 LEVEL_TEXT_LABEL_PERIOD_MS = 250
 
@@ -72,6 +74,8 @@ class Levels_Widget(QtWidgets.QWidget):
 
         # initialize the settings dialog
         self.settings_dialog = Levels_Settings_Dialog(self)
+
+        self.calibration = 0
 
         # initialize the class instance that will do the fft
         self.proc = audioproc()
@@ -136,6 +140,7 @@ class Levels_Widget(QtWidgets.QWidget):
         self.old_rms = value_rms
 
         self.level_view_model.level_data.level_rms = 10. * np.log10(value_rms + 0. * 1e-80)
+        self.level_view_model.level_data.level_spl = self.level_view_model.level_data.level_rms + 94.0 + self.calibration
         self.level_view_model.level_data.level_max = 20. * np.log10(self.old_max + 0. * 1e-80)
         self.level_view_model.level_data_ballistic.peak_iec = dB_to_IEC(max(self.level_view_model.level_data.level_max, self.level_view_model.level_data.level_rms))
 
@@ -156,7 +161,10 @@ class Levels_Widget(QtWidgets.QWidget):
             value_rms = pyx_exp_smoothed_value(self.kernel, self.alpha, y2 ** 2, self.old_rms_2)
             self.old_rms_2 = value_rms
 
+            value_spl = value_rms + 94.0 + self.calibration
+
             self.level_view_model.level_data_2.level_rms = 10. * np.log10(value_rms + 0. * 1e-80)
+            self.level_view_model.level_data_2.level_spl = self.level_view_model.level_data_2.level_rms + 94.0 + self.calibration
             self.level_view_model.level_data_2.level_max = 20. * np.log10(self.old_max_2 + 0. * 1e-80)
             self.level_view_model.level_data_ballistic_2.peak_iec = dB_to_IEC(max(self.level_view_model.level_data_2.level_max, self.level_view_model.level_data_2.level_rms))
 
@@ -169,10 +177,12 @@ class Levels_Widget(QtWidgets.QWidget):
 
         if self.i == LEVEL_TEXT_LABEL_STEPS:
             self.level_view_model.level_data_slow.level_rms = self.level_view_model.level_data.level_rms
+            self.level_view_model.level_data_slow.level_spl = self.level_view_model.level_data.level_spl
             self.level_view_model.level_data_slow.level_max = self.level_view_model.level_data.level_max
 
             if self.two_channels:
                 self.level_view_model.level_data_slow_2.level_rms = self.level_view_model.level_data_2.level_rms
+                self.level_view_model.level_data_slow_2.level_spl = self.level_view_model.level_data_2.level_spl
                 self.level_view_model.level_data_slow_2.level_max = self.level_view_model.level_data_2.level_max
 
         self.i = self.i % LEVEL_TEXT_LABEL_STEPS

--- a/friture/levels.py
+++ b/friture/levels.py
@@ -78,7 +78,7 @@ class Levels_Widget(QtWidgets.QWidget):
         self.calibration = 0
 
         # initialize the class instance that will do the fft
-        self.proc = audioproc()
+        self.proc = audioproc(self)
 
         # time = SMOOTH_DISPLAY_TIMER_PERIOD_MS/1000. #DISPLAY
         # time = 0.025 #IMPULSE setting for a sound level meter
@@ -160,8 +160,6 @@ class Levels_Widget(QtWidgets.QWidget):
             # exponential smoothing for RMS
             value_rms = pyx_exp_smoothed_value(self.kernel, self.alpha, y2 ** 2, self.old_rms_2)
             self.old_rms_2 = value_rms
-
-            value_spl = value_rms + 94.0 + self.calibration
 
             self.level_view_model.level_data_2.level_rms = 10. * np.log10(value_rms + 0. * 1e-80)
             self.level_view_model.level_data_2.level_spl = self.level_view_model.level_data_2.level_rms + 94.0 + self.calibration

--- a/friture/longlevels.py
+++ b/friture/longlevels.py
@@ -143,7 +143,7 @@ class LongLevelWidget(QtWidgets.QWidget):
         self.settings_dialog = LongLevels_Settings_Dialog(self)
 
         # initialize the class instance that will do the fft
-        self.proc = audioproc()
+        self.proc = audioproc(self)
 
         self.level = None  # 1e-30
         self.level_rms = -200.

--- a/friture/octavefilters.py
+++ b/friture/octavefilters.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Friture.  If not, see <http://www.gnu.org/licenses/>.
 
-from numpy import log10, array, where
+from numpy import log10, array, where, interp
 
 from friture.filter import (octave_filter_bank_decimation, octave_frequencies,
                             octave_filter_bank_decimation_filtic, NOCTAVE)
@@ -26,11 +26,15 @@ import friture.renard as renard
 
 class Octave_Filters():
 
-    def __init__(self, bandsperoctave):
+    def __init__(self, parent, bandsperoctave):
         [self.bdec, self.adec] = generated_filters.PARAMS['dec']
 
         self.bdec = array(self.bdec)
         self.adec = array(self.adec)
+
+        self.calibration = []
+
+        self.parent_widget = parent
 
         self.setbandsperoctave(bandsperoctave)
 
@@ -48,11 +52,20 @@ class Octave_Filters():
 
         return decs
 
+    def recalculate_calibration(self):
+        try:
+            
+            self.calibration = interp(self.fi, self.parent_widget.parent().dockmanager.parent().original_calibration_freqs, self.parent_widget.parent().dockmanager.parent().original_calibration)
+        except:
+            self.calibration = [0 for i in self.fi]
+
     def setbandsperoctave(self, bandsperoctave):
         self.bandsperoctave = bandsperoctave
         self.nbands = NOCTAVE * self.bandsperoctave
         self.fi, self.flow, self.fhigh = octave_frequencies(self.nbands, self.bandsperoctave)
         [self.boct, self.aoct, fi, flow, fhigh] = generated_filters.PARAMS['%d' % bandsperoctave]
+
+        self.recalculate_calibration()
 
         self.boct = [array(f) for f in self.boct]
         self.aoct = [array(f) for f in self.aoct]

--- a/friture/octavespectrum.py
+++ b/friture/octavespectrum.py
@@ -61,7 +61,7 @@ class OctaveSpectrum_Widget(QtWidgets.QWidget):
         self.PlotZoneSpect.setspecrange(self.spec_min, self.spec_max)
         self.PlotZoneSpect.setweighting(self.weighting)
 
-        self.filters = Octave_Filters(DEFAULT_BANDSPEROCTAVE)
+        self.filters = Octave_Filters(self, DEFAULT_BANDSPEROCTAVE)
         self.dispbuffers = [0] * DEFAULT_BANDSPEROCTAVE * NOCTAVE
 
         # set kernel and parameters for the smoothing filter
@@ -118,7 +118,7 @@ class OctaveSpectrum_Widget(QtWidgets.QWidget):
             w = self.filters.C
 
         epsilon = 1e-30
-        db_spectrogram = 10 * log10(sp + epsilon) + w
+        db_spectrogram = 10 * log10(sp + epsilon) + w + self.filters.calibration
         self.PlotZoneSpect.setdata(self.filters.flow, self.filters.fhigh, self.filters.f_nominal, db_spectrogram)
 
     # method

--- a/friture/pitch_tracker.py
+++ b/friture/pitch_tracker.py
@@ -265,7 +265,7 @@ class PitchTracker:
         self.out_buf = RingBuffer()
         self.out_offset = self.out_buf.offset
 
-        self.proc = audioproc()
+        self.proc = audioproc(self)
         self.proc.set_fftsize(self.fft_size)
 
     def set_input_buffer(self, new_buf: RingBuffer) -> None:

--- a/friture/spectrogram.py
+++ b/friture/spectrogram.py
@@ -58,7 +58,7 @@ class Spectrogram_Widget(QtWidgets.QWidget):
         self.audiobuffer = None
 
         # initialize the class instance that will do the fft
-        self.proc = audioproc()
+        self.proc = audioproc(self)
 
         self.frequency_resampler = Frequency_Resampler()
         self.screen_resampler = Online_Linear_2D_resampler()
@@ -159,6 +159,7 @@ class Spectrogram_Widget(QtWidgets.QWidget):
 
             w = tile(self.w, (1, realizable))
             norm_spectrogram = self.scale_spectrogram(self.log_spectrogram(spn) + w)
+            #norm_spectrogram = self.scale_spectrogram(self.log_spectrogram(spn) + w + self.proc.calibration) # This produces lags
 
             self.screen_resampler.set_height(self.PlotZoneImage.spectrogram_screen_height())
             screen_rate_frac = Fraction(self.PlotZoneImage.spectrogram_screen_width(), int(self.timerange_s * 1000))

--- a/friture/spectrum.py
+++ b/friture/spectrum.py
@@ -53,7 +53,7 @@ class Spectrum_Widget(QtWidgets.QWidget):
         self.gridLayout.addWidget(self.PlotZoneSpect, 0, 0, 1, 1)
 
         # initialize the class instance that will do the fft
-        self.proc = audioproc()
+        self.proc = audioproc(self)
 
         self.maxfreq = DEFAULT_MAXFREQ
         self.proc.set_maxfreq(self.maxfreq)
@@ -159,7 +159,7 @@ class Spectrum_Widget(QtWidgets.QWidget):
             if self.dual_channels and floatdata.shape[0] > 1:
                 dB_spectrogram = self.log_spectrogram(sp2) - self.log_spectrogram(sp1)
             else:
-                dB_spectrogram = self.log_spectrogram(sp1) + self.w
+                dB_spectrogram = self.log_spectrogram(sp1) + self.w + self.proc.calibration
 
             # the log operation and the weighting could be deffered
             # to the post-weedening !

--- a/friture/spl.py
+++ b/friture/spl.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2024 NathaU
+
+# This file is part of Friture.
+#
+# Friture is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as published by
+# the Free Software Foundation.
+#
+# Friture is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Friture.  If not, see <http://www.gnu.org/licenses/>.
+
+from PyQt5 import QtWidgets
+from numpy import log10, argmax, zeros, arange, floor, float64
+from friture.audioproc import audioproc  # audio processing class
+from friture.spl_settings import (SPL_Settings_Dialog,  # settings dialog
+                                       DEFAULT_FFT_SIZE,
+                                       DEFAULT_FREQ_SCALE,
+                                       DEFAULT_MAXFREQ,
+                                       DEFAULT_MINFREQ,
+                                       DEFAULT_SPEC_MIN,
+                                       DEFAULT_SPEC_MAX,
+                                       DEFAULT_WEIGHTING,
+                                       DEFAULT_RESPONSE_TIME,
+                                       DEFAULT_SHOW_FREQ_LABELS)
+import friture.plotting.frequency_scales as fscales
+
+from friture.audiobackend import SAMPLING_RATE
+from friture.splPlotWidget import SPLPlotWidget
+from friture_extensions.exp_smoothing_conv import pyx_exp_smoothed_value_numpy
+
+
+class SPL_Widget(QtWidgets.QWidget):
+
+    def __init__(self, parent, engine):
+        super().__init__(parent)
+
+        self.audiobuffer = None
+
+        self.setObjectName("Spectrum_Widget")
+        self.gridLayout = QtWidgets.QGridLayout(self)
+        self.gridLayout.setObjectName("gridLayout")
+        self.gridLayout.setContentsMargins(2, 2, 2, 2)
+        self.PlotZoneSpect = SPLPlotWidget(self, engine)
+        self.PlotZoneSpect.setObjectName("PlotZoneSpect")
+        self.gridLayout.addWidget(self.PlotZoneSpect, 0, 0, 1, 1)
+
+        # initialize the class instance that will do the fft
+        self.proc = audioproc()
+
+        self.maxfreq = DEFAULT_MAXFREQ
+        self.proc.set_maxfreq(self.maxfreq)
+        self.minfreq = DEFAULT_MINFREQ
+        self.fft_size = 2 ** DEFAULT_FFT_SIZE * 32
+        self.proc.set_fftsize(self.fft_size)
+        self.spec_min = DEFAULT_SPEC_MIN
+        self.spec_max = DEFAULT_SPEC_MAX
+        self.weighting = DEFAULT_WEIGHTING
+        self.dual_channels = False
+        self.response_time = DEFAULT_RESPONSE_TIME
+        self.calibration = 1
+
+        self.update_weighting()
+        self.freq = self.proc.get_freq_scale()
+
+        self.old_index = 0
+        self.overlap = 3. / 4.
+
+        self.update_display_buffers()
+
+        # set kernel and parameters for the smoothing filter
+        self.setresponsetime(self.response_time)
+
+        self.PlotZoneSpect.setfreqscale(fscales.Mel) # matches DEFAULT_FREQ_SCALE = 2 #Mel
+        self.PlotZoneSpect.setfreqrange(self.minfreq, self.maxfreq)
+        self.PlotZoneSpect.setspecrange(self.spec_min, self.spec_max)
+        self.PlotZoneSpect.setweighting(self.weighting)
+        self.PlotZoneSpect.set_peaks_enabled(True)
+        self.PlotZoneSpect.set_baseline_displayUnits(0.)
+        self.PlotZoneSpect.setShowFreqLabel(DEFAULT_SHOW_FREQ_LABELS)
+
+        # initialize the settings dialog
+        self.settings_dialog = SPL_Settings_Dialog(self)
+
+    # method
+    def set_buffer(self, buffer):
+        self.audiobuffer = buffer
+        self.old_index = self.audiobuffer.ringbuffer.offset
+
+    def log_spectrogram(self, sp):
+        # Note: implementing the log10 of the array in Cython did not bring
+        # any speedup.
+        # Idea: Instead of computing the log of the data, I could pre-compute
+        # a list of values associated with the colormap, and then do a search...
+        epsilon = 1e-30
+        return 10. * log10(sp + epsilon)
+
+    def harmonic_product_spectrum(self, sp):
+        # Chose 3 harmonics for no particularly good reason; initial results
+        # for pitch detection are good.
+        product_count = 3
+  
+        # Downsample and multiply
+        harmonic_length = sp.shape[0] // product_count
+        res = sp[:harmonic_length]
+        for i in range(2, product_count + 1):
+            res *= sp[::i][:harmonic_length]
+        return res
+
+    def handle_new_data(self, floatdata):
+        # we need to maintain an index of where we are in the buffer
+        index = self.audiobuffer.ringbuffer.offset
+
+        available = index - self.old_index
+
+        if available < 0:
+            # ringbuffer must have grown or something...
+            available = 0
+            self.old_index = index
+
+        # if we have enough data to add a frequency column in the time-frequency plane, compute it
+        needed = self.fft_size * (1. - self.overlap)
+        realizable = int(floor(available / needed))
+
+        if realizable > 0:
+            sp1n = zeros((len(self.freq), realizable), dtype=float64)
+            sp2n = zeros((len(self.freq), realizable), dtype=float64)
+
+            for i in range(realizable):
+                floatdata = self.audiobuffer.data_indexed(self.old_index, self.fft_size)
+
+                # first channel
+                # FFT transform
+                sp1n[:, i] = self.proc.analyzelive(floatdata[0, :])
+
+                if self.dual_channels and floatdata.shape[0] > 1:
+                    # second channel for comparison
+                    sp2n[:, i] = self.proc.analyzelive(floatdata[1, :])
+
+                self.old_index += int(needed)
+
+            # compute the widget data
+            sp1 = pyx_exp_smoothed_value_numpy(self.kernel, self.alpha, sp1n, self.dispbuffers1)
+            sp2 = pyx_exp_smoothed_value_numpy(self.kernel, self.alpha, sp2n, self.dispbuffers2)
+            # store result for next computation
+            self.dispbuffers1 = sp1
+            self.dispbuffers2 = sp2
+
+            sp1.shape = self.freq.shape
+            sp2.shape = self.freq.shape
+            self.w.shape = self.freq.shape
+
+            if self.dual_channels and floatdata.shape[0] > 1:
+                dB_spectrogram = self.log_spectrogram(sp2) - self.log_spectrogram(sp1)
+            else:
+                dB_spectrogram = self.log_spectrogram(sp1) + self.w
+
+            # the log operation and the weighting could be deffered
+            # to the post-weedening !
+            i = argmax(dB_spectrogram)
+            fmax = self.freq[i]
+
+            # The maximum value in the harmonic product spectrum is quite
+            # likely to correspond to a fundamental frequency.
+            harmonic_products = self.harmonic_product_spectrum(sp1)
+            pitch_idx = argmax(harmonic_products)
+            fpitch = max(self.freq[pitch_idx], 1e-20)
+
+            dB_spectrogram = dB_spectrogram + 94.0 + self.calibration # if db_spectrogram is in dB RMS, thenn just add 94db + calibration factor in db
+
+            self.PlotZoneSpect.setdata(self.freq, dB_spectrogram, fmax, fpitch)
+
+    # method
+    def canvasUpdate(self):
+        self.PlotZoneSpect.canvasUpdate()
+
+    def pause(self):
+        self.PlotZoneSpect.pause()
+
+    def restart(self):
+        self.PlotZoneSpect.restart()
+
+    def setresponsetime(self, response_time):
+        # time = SMOOTH_DISPLAY_TIMER_PERIOD_MS/1000. #DISPLAY
+        # time = 0.025 #IMPULSE setting for a sound level meter
+        # time = 0.125 #FAST setting for a sound level meter
+        # time = 1. #SLOW setting for a sound level meter
+        self.response_time = response_time
+
+        # an exponential smoothing filter is a simple IIR filter
+        # s_i = alpha*x_i + (1-alpha)*s_{i-1}
+        # we compute alpha so that the N most recent samples represent 100*w percent of the output
+        w = 0.65
+        delta_n = self.fft_size * (1. - self.overlap)
+        n = self.response_time * SAMPLING_RATE / delta_n
+        N = 2 * 4096
+        self.alpha = 1. - (1. - w) ** (1. / (n + 1))
+        self.kernel = self.compute_kernel(self.alpha, N)
+
+    def compute_kernel(self, alpha, N):
+        kernel = (1. - alpha) ** arange(N - 1, -1, -1)
+        return kernel
+
+    def update_display_buffers(self):
+        self.dispbuffers1 = zeros(len(self.freq))
+        self.dispbuffers2 = zeros(len(self.freq))
+
+    def setminfreq(self, minfreq):
+        self.setMinMaxFreq(minfreq, self.maxfreq)
+
+    def setmaxfreq(self, maxfreq):
+        self.setMinMaxFreq(self.minfreq, maxfreq)
+
+    def setMinMaxFreq(self, minfreq, maxfreq):
+        self.minfreq = minfreq
+        self.maxfreq = maxfreq
+
+        realmin = min(self.minfreq, self.maxfreq)
+        realmax = max(self.minfreq, self.maxfreq)
+
+        self.proc.set_maxfreq(realmax)
+
+        self.freq = self.proc.get_freq_scale()
+        self.update_display_buffers()
+        self.update_weighting()
+        # reset kernel and parameters for the smoothing filter
+        self.setresponsetime(self.response_time)
+
+        self.PlotZoneSpect.setfreqrange(realmin, realmax)
+
+    def setfftsize(self, fft_size):
+        self.fft_size = fft_size
+        self.proc.set_fftsize(self.fft_size)
+        self.freq = self.proc.get_freq_scale()
+        self.update_display_buffers()
+        self.update_weighting()
+        # reset kernel and parameters for the smoothing filter
+        self.setresponsetime(self.response_time)
+
+    def setmin(self, value):
+        #self.spec_min = value
+        self.PlotZoneSpect.setspecrange(self.spec_min, self.spec_max)
+
+    def setmax(self, value):
+        #self.spec_max = value
+        self.PlotZoneSpect.setspecrange(self.spec_min, self.spec_max)
+
+    def setweighting(self, weighting):
+        self.weighting = weighting
+        self.PlotZoneSpect.setweighting(weighting)
+        self.update_weighting()
+
+    def update_weighting(self):
+        A, B, C = self.proc.get_freq_weighting()
+        if self.weighting == 0:
+            self.w = A
+        elif self.weighting == 1:
+            self.w = B
+        else:
+            self.w = C
+
+        self.w.shape = (1, self.w.size)
+
+    def setdualchannels(self, dual_enabled):
+        self.dual_channels = dual_enabled
+        if dual_enabled:
+            self.PlotZoneSpect.set_peaks_enabled(False)
+            self.PlotZoneSpect.set_baseline_dataUnits(0.)
+        else:
+            self.PlotZoneSpect.set_peaks_enabled(True)
+            self.PlotZoneSpect.set_baseline_displayUnits(0.)
+
+    def setShowFreqLabel(self, showFreqLabel):
+        self.PlotZoneSpect.setShowFreqLabel(showFreqLabel)
+
+    def setShowPitchLabel(self, showPitchLabel):
+        self.PlotZoneSpect.setShowPitchLabel(showPitchLabel)
+
+    def settings_called(self, checked):
+        self.settings_dialog.show()
+
+    def saveState(self, settings):
+        self.settings_dialog.saveState(settings)
+
+    def restoreState(self, settings):
+        self.settings_dialog.restoreState(settings)
+    
+    def setcalibration(self, calibration_db):
+        self.calibration = calibration_db

--- a/friture/spl.py
+++ b/friture/spl.py
@@ -53,7 +53,7 @@ class SPL_Widget(QtWidgets.QWidget):
         self.gridLayout.addWidget(self.PlotZoneSpect, 0, 0, 1, 1)
 
         # initialize the class instance that will do the fft
-        self.proc = audioproc()
+        self.proc = audioproc(self)
 
         self.maxfreq = DEFAULT_MAXFREQ
         self.proc.set_maxfreq(self.maxfreq)
@@ -160,7 +160,7 @@ class SPL_Widget(QtWidgets.QWidget):
             if self.dual_channels and floatdata.shape[0] > 1:
                 dB_spectrogram = self.log_spectrogram(sp2) - self.log_spectrogram(sp1)
             else:
-                dB_spectrogram = self.log_spectrogram(sp1) + self.w
+                dB_spectrogram = self.log_spectrogram(sp1) + self.w + self.proc.calibration
 
             # the log operation and the weighting could be deffered
             # to the post-weedening !

--- a/friture/splPlotWidget.py
+++ b/friture/splPlotWidget.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from enum import Enum
+import logging
+
+from PyQt5 import QtWidgets
+from PyQt5.QtQuickWidgets import QQuickWidget
+
+from numpy import zeros, ones, log10
+import numpy as np
+
+from friture.audiobackend import SAMPLING_RATE
+from friture.plotting.coordinateTransform import CoordinateTransform
+from friture.spl_data import SPLData
+from friture.filled_curve import CurveType, FilledCurve
+from friture.pitch_tracker import format_frequency
+from friture.store import GetStore
+from friture.qml_tools import qml_url, raise_if_error
+
+# The peak decay rates (magic goes here :).
+PEAK_DECAY_RATE = 1.0 - 3e-6
+# Number of cycles the peak stays on hold before fall-off.
+PEAK_FALLOFF_COUNT = 32  # default : 16
+
+
+class Baseline(Enum):
+    PLOT_BOTTOM = (1,)
+    DATA_ZERO = 2
+
+
+class SPLPlotWidget(QtWidgets.QWidget):
+
+    def __init__(self, parent, engine):
+        super(SPLPlotWidget, self).__init__(parent)
+
+        self.logger = logging.getLogger(__name__)
+
+        store = GetStore()
+        self._SPLData = SPLData(store)
+        store._dock_states.append(self._SPLData)
+        state_id = len(store._dock_states) - 1
+
+        self._curve_signal = FilledCurve(CurveType.SIGNAL)
+        self._SPLData.add_plot_item(self._curve_signal)
+
+        self._curve_peak = FilledCurve(CurveType.PEEK)
+
+        self._SPLData.show_legend = False
+        self._SPLData.vertical_axis.name = "SPL (dB)"
+        self._SPLData.vertical_axis.setTrackerFormatter(lambda x: "%.1f dB" % (x))
+        self._SPLData.horizontal_axis.name = "Frequency (Hz)"
+        self._SPLData.horizontal_axis.setTrackerFormatter(format_frequency)
+        self._SPLData.horizontal_axis.show_minor_grid_lines = True
+
+        self._SPLData.vertical_axis.setRange(0, 1)
+        self._SPLData.horizontal_axis.setRange(0, 22000)
+
+        self._baseline = Baseline.PLOT_BOTTOM
+
+        self.paused = False
+
+        self.peaks_enabled = True
+        self.peak = zeros((3,))
+        self.peak_int = zeros((3,))
+        self.peak_decay = ones((3,)) * PEAK_DECAY_RATE
+
+        self.normVerticalScaleTransform = CoordinateTransform(0, 1, 1, 0, 0)
+        self.normHorizontalScaleTransform = CoordinateTransform(0, 22000, 1, 0, 0)
+
+        plotLayout = QtWidgets.QGridLayout(self)
+        plotLayout.setSpacing(0)
+        plotLayout.setContentsMargins(0, 0, 0, 0)
+
+        self.quickWidget = QQuickWidget(engine, self)
+        self.quickWidget.statusChanged.connect(self.on_status_changed)
+        self.quickWidget.setResizeMode(QQuickWidget.SizeRootObjectToView)
+        self.quickWidget.setSizePolicy(
+            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding
+        )
+        self.quickWidget.setSource(qml_url("SPL.qml"))
+
+        raise_if_error(self.quickWidget)
+
+        self.quickWidget.rootObject().setProperty("stateId", state_id)
+
+        plotLayout.addWidget(self.quickWidget)
+
+        self.setLayout(plotLayout)
+
+    def on_status_changed(self, status):
+        if status == QQuickWidget.Error:
+            for error in self.quickWidget.errors():
+                self.logger.error("QML error: " + error.toString())
+
+    def setfreqscale(self, scale):
+        self.normHorizontalScaleTransform.setScale(scale)
+        self._SPLData.horizontal_axis.setScale(scale)
+
+    def setfreqrange(self, minfreq, maxfreq):
+        self.xmin = minfreq
+        self.xmax = maxfreq
+
+        self._SPLData.horizontal_axis.setRange(minfreq, maxfreq)
+        self.normHorizontalScaleTransform.setRange(minfreq, maxfreq)
+
+    def setspecrange(self, spec_min, spec_max):
+        if spec_min > spec_max:
+            spec_min, spec_max = spec_max, spec_min
+
+        self._SPLData.vertical_axis.setRange(spec_min, spec_max)
+        self.normVerticalScaleTransform.setRange(spec_min, spec_max)
+
+    def setweighting(self, weighting):
+        if weighting == 0:
+            title = "SPL (dB A)"
+        elif weighting == 1:
+            title = "SPL (dB B)"
+        else:
+            title = "SPL (dB C)"
+
+        self._SPLData.vertical_axis.name = title
+
+    def setShowFreqLabel(self, showFreqLabel):
+        self._SPLData.showFrequencyTracker = showFreqLabel
+
+    def setShowPitchLabel(self, showPitchLabel):
+        self._SPLData.showPitchTracker = showPitchLabel
+
+    def set_peaks_enabled(self, enabled):
+        self.peaks_enabled = enabled
+
+        if enabled:
+            self._SPLData.insert_plot_item(0, self._curve_peak)
+        else:
+            self._SPLData.remove_plot_item(self._curve_peak)
+
+    def set_baseline_displayUnits(self, baseline):
+        self._baseline = Baseline.PLOT_BOTTOM
+
+    def set_baseline_dataUnits(self, baseline):
+        self._baseline = Baseline.DATA_ZERO
+
+    def setdata(self, x, y, fmax, fpitch):
+        if not self.paused:
+            if fmax < 2e2:
+                text = "%.1f Hz" % (fmax)
+            else:
+                text = "%d Hz" % (np.rint(fmax))
+            self._SPLData.setFmax(
+                text, self.normHorizontalScaleTransform.toScreen(fmax)
+            )
+            self._SPLData.setFpitch(
+                format_frequency(fpitch),
+                self.normHorizontalScaleTransform.toScreen(fpitch),
+            )
+
+            M = np.max(y)
+            m = self.normVerticalScaleTransform.coord_min
+            y_int = (y - m) / (np.abs(M - m) + 1e-3)
+
+            x_left = zeros(x.shape)
+            x_right = zeros(x.shape)
+            x_left[0] = 1e-10
+            x_left[1:] = (x[1:] + x[:-1]) / 2.0
+            x_right[:-1] = x_left[1:]
+            x_right[-1] = float(SAMPLING_RATE / 2)
+            scaled_x_left = self.normHorizontalScaleTransform.toScreen(x_left)
+            scaled_x_right = self.normHorizontalScaleTransform.toScreen(x_right)
+
+            baseline = (
+                1.0
+                if self._baseline == Baseline.PLOT_BOTTOM
+                else (1.0 - self.normVerticalScaleTransform.toScreen(0.0))
+            )
+
+            scaled_y = 1.0 - self.normVerticalScaleTransform.toScreen(y)
+            z = y_int
+            self._curve_signal.setData(
+                scaled_x_left, scaled_x_right, scaled_y, z, baseline
+            )
+
+            if self.peaks_enabled:
+                self.compute_peaks(y)
+                scaled_peak = 1.0 - self.normVerticalScaleTransform.toScreen(self.peak)
+                z_peak = self.peak_int
+                self._curve_peak.setData(
+                    scaled_x_left, scaled_x_right, scaled_peak, z_peak, baseline
+                )
+
+    def draw(self):
+        return
+
+    def pause(self):
+        self.paused = True
+
+    def restart(self):
+        self.paused = False
+
+    def canvasUpdate(self):
+        return
+
+    def compute_peaks(self, y):
+        if len(self.peak) != len(y):
+            y_ones = ones(y.shape)
+            self.peak = y_ones * (-500.0)
+            self.peak_int = zeros(y.shape)
+            self.peak_decay = y_ones * 20.0 * log10(PEAK_DECAY_RATE) * 5000
+
+        mask1 = self.peak < y
+        mask2 = ~mask1
+        mask2_a = mask2 * (self.peak_int < 0.2)
+        mask2_b = mask2 * (self.peak_int >= 0.2)
+
+        self.peak[mask1] = y[mask1]
+        self.peak[mask2_a] = self.peak[mask2_a] + self.peak_decay[mask2_a]
+
+        self.peak_decay[mask1] = 20.0 * log10(PEAK_DECAY_RATE) * 5000
+        self.peak_decay[mask2_a] += 20.0 * log10(PEAK_DECAY_RATE) * 5000
+
+        self.peak_int[mask1] = 1.0
+        self.peak_int[mask2_b] *= 0.975

--- a/friture/spl_data.py
+++ b/friture/spl_data.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2021 Timothée Lecomte
+
+# This file is part of Friture.
+#
+# Friture is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as published by
+# the Free Software Foundation.
+#
+# Friture is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Friture.  If not, see <http://www.gnu.org/licenses/>.
+
+from PyQt5 import QtCore
+from PyQt5.QtCore import pyqtProperty
+
+from friture.scope_data import Scope_Data
+
+class SPLData(Scope_Data):
+    fmax_changed = QtCore.pyqtSignal()
+    fpitch_changed = QtCore.pyqtSignal()
+    show_frequency_tracker_changed = QtCore.pyqtSignal(bool)
+    show_pitch_tracker_changed = QtCore.pyqtSignal(bool)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        self._fmax_value = ""
+        self._fmax_logical_value = 0
+        self._fpitch_display = ""
+        self._fpitch_value = 0.0
+        self._show_frequency_tracker = True
+        self._show_pitch_tracker = True
+
+    @pyqtProperty(str, notify=fmax_changed) # type: ignore
+    def fmaxValue(self):
+        return self._fmax_value
+
+    @pyqtProperty(float, notify=fmax_changed) # type: ignore
+    def fmaxLogicalValue(self):
+        return self._fmax_logical_value
+
+    def setFmax(self, value, logical_value):
+        if self._fmax_value != value or self._fmax_logical_value != logical_value:
+            self._fmax_value = value
+            self._fmax_logical_value = logical_value
+            self.fmax_changed.emit()
+
+    @pyqtProperty(str, notify=fpitch_changed) # type: ignore
+    def fpitchDisplayText(self):
+        return self._fpitch_display
+
+    @pyqtProperty(float, notify=fpitch_changed) # type: ignore
+    def fpitchValue(self):
+        return self._fpitch_value
+
+    def setFpitch(self, display_text, value):
+        if self._fpitch_display != display_text or self._fpitch_value != value:
+            self._fpitch_display = display_text
+            self._fpitch_value = value
+            self.fpitch_changed.emit()
+
+    @pyqtProperty(bool, notify=show_frequency_tracker_changed) # type: ignore
+    def showFrequencyTracker(self):
+        return self._show_frequency_tracker
+
+    @showFrequencyTracker.setter # type: ignore
+    def showFrequencyTracker(self, show_frequency_tracker):
+        if self._show_frequency_tracker != show_frequency_tracker:
+            self._show_frequency_tracker = show_frequency_tracker
+            self.show_frequency_tracker_changed.emit(show_frequency_tracker)
+
+    @pyqtProperty(bool, notify=show_pitch_tracker_changed) # type: ignore
+    def showPitchTracker(self):
+        return self._show_pitch_tracker
+
+    @showPitchTracker.setter # type: ignore
+    def showPitchTracker(self, show_pitch_tracker):
+        if self._show_pitch_tracker != show_pitch_tracker:
+            self._show_pitch_tracker = show_pitch_tracker
+            self.show_pitch_tracker_changed.emit(show_pitch_tracker)

--- a/friture/spl_settings.py
+++ b/friture/spl_settings.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2009 Timoth?Lecomte
+
+# This file is part of Friture.
+#
+# Friture is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as published by
+# the Free Software Foundation.
+#
+# Friture is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Friture.  If not, see <http://www.gnu.org/licenses/>.
+
+
+# TODO: Take all other settings than calibration and weighting from FFT
+
+import logging
+
+from PyQt5 import QtWidgets
+from friture.audiobackend import SAMPLING_RATE
+from numpy import log10
+import friture.plotting.frequency_scales as fscales
+
+# shared with spectrum_settings.py
+DEFAULT_FFT_SIZE = 8  # 8192 points
+DEFAULT_FREQ_SCALE = 2  # Mel
+DEFAULT_MAXFREQ = 20000
+DEFAULT_MINFREQ = 20
+DEFAULT_SPEC_MIN = -30
+DEFAULT_SPEC_MAX = 130
+DEFAULT_WEIGHTING = 0  # A
+DEFAULT_CALIBRATION = 0.0
+DEFAULT_SHOW_FREQ_LABELS = True
+DEFAULT_SHOW_PITCH_LABELS = True
+DEFAULT_RESPONSE_TIME = 0.025
+DEFAULT_RESPONSE_TIME_INDEX = 0
+
+
+class SPL_Settings_Dialog(QtWidgets.QDialog):
+
+    def __init__(self, parent):
+        super().__init__(parent)
+
+        self.logger = logging.getLogger(__name__)
+
+        self.setWindowTitle("SPL settings")
+
+        self.formLayout = QtWidgets.QFormLayout(self)
+
+        self.comboBox_dual_channel = QtWidgets.QComboBox(self)
+        self.comboBox_dual_channel.setObjectName("dual")
+        self.comboBox_dual_channel.addItem("Single-channel")
+        self.comboBox_dual_channel.addItem("Dual-channel")
+        self.comboBox_dual_channel.setCurrentIndex(0)
+
+        self.comboBox_fftsize = QtWidgets.QComboBox(self)
+        self.comboBox_fftsize.setObjectName("comboBox_fftsize")
+        self.comboBox_fftsize.addItem("32 points")
+        self.comboBox_fftsize.addItem("64 points")
+        self.comboBox_fftsize.addItem("128 points")
+        self.comboBox_fftsize.addItem("256 points")
+        self.comboBox_fftsize.addItem("512 points")
+        self.comboBox_fftsize.addItem("1024 points")
+        self.comboBox_fftsize.addItem("2048 points")
+        self.comboBox_fftsize.addItem("4096 points")
+        self.comboBox_fftsize.addItem("8192 points")
+        self.comboBox_fftsize.addItem("16384 points")
+        self.comboBox_fftsize.setCurrentIndex(DEFAULT_FFT_SIZE)
+
+        self.comboBox_freqscale = QtWidgets.QComboBox(self)
+        self.comboBox_freqscale.setObjectName("comboBox_freqscale")
+        for scale in fscales.ALL:
+            self.comboBox_freqscale.addItem(scale.NAME)
+        self.comboBox_freqscale.setCurrentIndex(DEFAULT_FREQ_SCALE)
+
+        self.spinBox_minfreq = QtWidgets.QSpinBox(self)
+        self.spinBox_minfreq.setMinimum(20)
+        self.spinBox_minfreq.setMaximum(SAMPLING_RATE // 2)
+        self.spinBox_minfreq.setSingleStep(10)
+        self.spinBox_minfreq.setValue(DEFAULT_MINFREQ)
+        self.spinBox_minfreq.setObjectName("spinBox_minfreq")
+        self.spinBox_minfreq.setSuffix(" Hz")
+
+        self.doubleSpinBox_calibration = QtWidgets.QDoubleSpinBox(self)
+        self.doubleSpinBox_calibration.setDecimals(10)
+        self.doubleSpinBox_calibration.setMinimum(1)
+        self.doubleSpinBox_calibration.setMaximum(1000)
+        self.doubleSpinBox_calibration.setValue(DEFAULT_CALIBRATION)
+        self.doubleSpinBox_calibration.setObjectName("doubleSpinBox_calibration")
+
+        self.spinBox_maxfreq = QtWidgets.QSpinBox(self)
+        self.spinBox_maxfreq.setMinimum(20)
+        self.spinBox_maxfreq.setMaximum(SAMPLING_RATE // 2)
+        self.spinBox_maxfreq.setSingleStep(1000)
+        self.spinBox_maxfreq.setProperty("value", DEFAULT_MAXFREQ)
+        self.spinBox_maxfreq.setObjectName("spinBox_maxfreq")
+        self.spinBox_maxfreq.setSuffix(" Hz")
+
+        self.spinBox_specmin = QtWidgets.QSpinBox(self)
+        self.spinBox_specmin.setKeyboardTracking(False)
+        self.spinBox_specmin.setMinimum(-200)
+        self.spinBox_specmin.setMaximum(200)
+        self.spinBox_specmin.setProperty("value", DEFAULT_SPEC_MIN)
+        self.spinBox_specmin.setObjectName("spinBox_specmin")
+        self.spinBox_specmin.setSuffix(" dB")
+
+        self.spinBox_specmax = QtWidgets.QSpinBox(self)
+        self.spinBox_specmax.setKeyboardTracking(False)
+        self.spinBox_specmax.setMinimum(-200)
+        self.spinBox_specmax.setMaximum(200)
+        self.spinBox_specmax.setProperty("value", DEFAULT_SPEC_MAX)
+        self.spinBox_specmax.setObjectName("spinBox_specmax")
+        self.spinBox_specmax.setSuffix(" dB")
+
+        self.comboBox_weighting = QtWidgets.QComboBox(self)
+        self.comboBox_weighting.setObjectName("weighting")
+        self.comboBox_weighting.addItem("A")
+        self.comboBox_weighting.addItem("B")
+        self.comboBox_weighting.addItem("C")
+        self.comboBox_weighting.setCurrentIndex(DEFAULT_WEIGHTING)
+
+        self.comboBox_response_time = QtWidgets.QComboBox(self)
+        self.comboBox_response_time.setObjectName("response_time")
+        self.comboBox_response_time.addItem("25 ms (Impulse)")
+        self.comboBox_response_time.addItem("125 ms (Fast)")
+        self.comboBox_response_time.addItem("300 ms")
+        self.comboBox_response_time.addItem("1s (Slow)")
+        self.comboBox_response_time.addItem("5s (Very Slow)")
+        self.comboBox_response_time.setCurrentIndex(DEFAULT_RESPONSE_TIME_INDEX)
+
+        self.checkBox_showFreqLabels = QtWidgets.QCheckBox(self)
+        self.checkBox_showFreqLabels.setObjectName("showFreqLabels")
+        self.checkBox_showFreqLabels.setChecked(DEFAULT_SHOW_FREQ_LABELS)
+
+        self.checkBox_showPitchLabel = QtWidgets.QCheckBox(self)
+        self.checkBox_showPitchLabel.setObjectName("showPitchLabels")
+        self.checkBox_showPitchLabel.setChecked(DEFAULT_SHOW_PITCH_LABELS)
+
+        self.formLayout.addRow("Measurement type:", self.comboBox_dual_channel)
+        self.formLayout.addRow("FFT Size:", self.comboBox_fftsize)
+        self.formLayout.addRow("Frequency scale:", self.comboBox_freqscale)
+        self.formLayout.addRow("Calibration factor:", self.doubleSpinBox_calibration)
+        self.formLayout.addRow("Min frequency:", self.spinBox_minfreq)
+        self.formLayout.addRow("Max frequency:", self.spinBox_maxfreq)
+        self.formLayout.addRow("Min:", self.spinBox_specmin)
+        self.formLayout.addRow("Max:", self.spinBox_specmax)
+        self.formLayout.addRow("Middle-ear weighting:", self.comboBox_weighting)
+        self.formLayout.addRow("Response time:", self.comboBox_response_time)
+        self.formLayout.addRow("Display max-frequency label:", self.checkBox_showFreqLabels)
+        self.formLayout.addRow("Display pitch label:", self.checkBox_showPitchLabel)
+
+        self.setLayout(self.formLayout)
+
+        self.comboBox_dual_channel.currentIndexChanged.connect(self.dualchannelchanged)
+        self.comboBox_fftsize.currentIndexChanged.connect(self.fftsizechanged)
+        self.comboBox_freqscale.currentIndexChanged.connect(self.freqscalechanged)
+        self.doubleSpinBox_calibration.valueChanged.connect(self.setcalibration)
+        self.spinBox_minfreq.valueChanged.connect(self.parent().setminfreq)
+        self.spinBox_maxfreq.valueChanged.connect(self.parent().setmaxfreq)
+        self.spinBox_specmin.valueChanged.connect(self.parent().setmin)
+        self.spinBox_specmax.valueChanged.connect(self.parent().setmax)
+        self.comboBox_weighting.currentIndexChanged.connect(self.parent().setweighting)
+        self.comboBox_response_time.currentIndexChanged.connect(self.responsetimechanged)
+        self.checkBox_showFreqLabels.toggled.connect(self.parent().setShowFreqLabel)
+        self.checkBox_showPitchLabel.toggled.connect(self.parent().setShowPitchLabel)
+
+    # slot
+    def dualchannelchanged(self, index):
+        if index == 0:
+            self.parent().setdualchannels(False)
+        else:
+            self.parent().setdualchannels(True)
+    
+    def setcalibration(self, value):
+        self.logger.info("calibration changed %f", value)
+        self.parent().setcalibration(20. * log10(value))
+        self.parent().parent().dockmanager.parent().level_widget.calibration = 20. * log10(value)
+
+    # slot
+    def fftsizechanged(self, index):
+        self.logger.info("fft_size_changed slot %d %d %f", index, 2 ** index * 32, 150000 / 2 ** index * 32)
+        # FIXME the size should not be found from the index, but attached as item data
+        fft_size = 2 ** index * 32
+        self.parent().setfftsize(fft_size)
+
+    # slot
+    def freqscalechanged(self, index):
+        self.logger.info("freq_scale slot %d %s", index, fscales.ALL[index].NAME)
+        self.parent().PlotZoneSpect.setfreqscale(fscales.ALL[index])
+
+    # slot
+    def responsetimechanged(self, index):
+        if index == 0:
+            response_time = 0.025
+        elif index == 1:
+            response_time = 0.125
+        elif index == 2:
+            response_time = 0.3
+        elif index == 3:
+            response_time = 1.
+        elif index == 4:
+            response_time = 5.            
+        self.logger.info("responsetimechanged slot %d %d", index, response_time)
+        self.parent().setresponsetime(response_time)
+
+    # method
+    def saveState(self, settings):
+        settings.setValue("fftSize", self.comboBox_fftsize.currentIndex())
+        settings.setValue("freqScale", self.comboBox_freqscale.currentIndex())
+        settings.setValue("calibration", self.doubleSpinBox_calibration.value())
+        settings.setValue("freqMin", self.spinBox_minfreq.value())
+        settings.setValue("freqMax", self.spinBox_maxfreq.value())
+        settings.setValue("Min", self.spinBox_specmin.value())
+        settings.setValue("Max", self.spinBox_specmax.value())
+        settings.setValue("weighting", self.comboBox_weighting.currentIndex())
+        settings.setValue("responseTime", self.comboBox_response_time.currentIndex())
+        settings.setValue("showFreqLabels", self.checkBox_showFreqLabels.isChecked())
+        settings.setValue("showPitchLabel", self.checkBox_showPitchLabel.isChecked())
+
+    # method
+    def restoreState(self, settings):
+        fft_size = settings.value("fftSize", DEFAULT_FFT_SIZE, type=int)  # 7th index is 1024 points
+        self.comboBox_fftsize.setCurrentIndex(fft_size)
+        freqscale = settings.value("freqScale", DEFAULT_FREQ_SCALE, type=int)
+        self.comboBox_freqscale.setCurrentIndex(freqscale)
+        calibration = settings.value("calibration", DEFAULT_CALIBRATION, type=float)
+        self.doubleSpinBox_calibration.setValue(calibration)
+        freqMin = settings.value("freqMin", DEFAULT_MINFREQ, type=int)
+        self.spinBox_minfreq.setValue(freqMin)
+        freqMax = settings.value("freqMax", DEFAULT_MAXFREQ, type=int)
+        self.spinBox_maxfreq.setValue(freqMax)
+        colorMin = settings.value("Min", DEFAULT_SPEC_MIN, type=int)
+        self.spinBox_specmin.setValue(colorMin)
+        colorMax = settings.value("Max", DEFAULT_SPEC_MAX, type=int)
+        self.spinBox_specmax.setValue(colorMax)
+        weighting = settings.value("weighting", DEFAULT_WEIGHTING, type=int)
+        self.comboBox_weighting.setCurrentIndex(weighting)
+        responseTime = settings.value("responseTime", DEFAULT_RESPONSE_TIME_INDEX, type=int)
+        self.comboBox_response_time.setCurrentIndex(responseTime)
+        showFreqLabels = settings.value("showFreqLabels", DEFAULT_SHOW_FREQ_LABELS, type=bool)
+        self.checkBox_showFreqLabels.setChecked(showFreqLabels)
+        showPitchLabel = settings.value("showPitchLabel", DEFAULT_SHOW_PITCH_LABELS, type=bool)
+        self.checkBox_showPitchLabel.setChecked(showPitchLabel)

--- a/friture/ui_settings.py
+++ b/friture/ui_settings.py
@@ -30,6 +30,20 @@ class Ui_Settings_Dialog(object):
         self.comboBox_inputDevice = QtWidgets.QComboBox(self.inputGroup)
         self.comboBox_inputDevice.setObjectName("comboBox_inputDevice")
         self.verticalLayout_6.addWidget(self.comboBox_inputDevice)
+        self.label_inputType_3 = QtWidgets.QLabel(self.inputGroup)
+        self.label_inputType_3.setObjectName("label_inputType_3")
+        self.verticalLayout_6.addWidget(self.label_inputType_3)
+        
+        # Add horizontal layout for QLineEdit and buttons
+        self.horizontalLayout_file = QtWidgets.QHBoxLayout()
+        self.fileBox_compensation = QtWidgets.QPushButton("Browse", self.inputGroup)
+        self.fileBox_compensation.setObjectName("fileButton")
+        self.horizontalLayout_file.addWidget(self.fileBox_compensation)
+        self.clearButton = QtWidgets.QPushButton("Clear", self.inputGroup)
+        self.clearButton.setObjectName("clearButton")
+        self.horizontalLayout_file.addWidget(self.clearButton)
+        self.verticalLayout_6.addLayout(self.horizontalLayout_file)
+        
         self.horizontalLayout = QtWidgets.QHBoxLayout()
         self.horizontalLayout.setObjectName("horizontalLayout")
         self.verticalLayout_3 = QtWidgets.QVBoxLayout()
@@ -108,6 +122,7 @@ class Ui_Settings_Dialog(object):
         Settings_Dialog.setWindowTitle(_translate("Settings_Dialog", "Settings"))
         self.inputGroup.setTitle(_translate("Settings_Dialog", "Input"))
         self.label_inputType_2.setText(_translate("Settings_Dialog", "Select the input device :"))
+        self.label_inputType_3.setText(_translate("Settings_Dialog", "Select the compensation file:"))
         self.label_inputType.setText(_translate("Settings_Dialog", "Select the type of input :"))
         self.radioButton_single.setText(_translate("Settings_Dialog", "Single channel"))
         self.radioButton_duo.setText(_translate("Settings_Dialog", "Two channels"))

--- a/friture/widgetdict.py
+++ b/friture/widgetdict.py
@@ -19,6 +19,7 @@
 
 from friture.levels import Levels_Widget
 from friture.spectrum import Spectrum_Widget
+from friture.spl import SPL_Widget
 from friture.spectrogram import Spectrogram_Widget
 from friture.octavespectrum import OctaveSpectrum_Widget
 from friture.scope import Scope_Widget
@@ -36,6 +37,7 @@ widgets = [
     {'Id': 6, "Class": Delay_Estimator_Widget, "Name": "Delay Estimator"},
     {'Id': 7, "Class": LongLevelWidget, "Name": "Long-time levels"},
     {'Id': 8, "Class": PitchTrackerWidget, "Name": "Pitch Tracker"},
+    {'Id': 9, "Class": SPL_Widget, "Name": "SPL"},
 ]
 
 


### PR DESCRIPTION
Closes #259. Adds a global setting that offers to input a microphone calibration file. This calibration is applied to FFT and SPL spectrum.

Also added a SPL dock and level value that offers to input a microphone calibration factor (see https://nl.mathworks.com/help/audio/ref/calibratemicrophone.html) to directly measure SPL