### PR TITLE
chore(ci): update to ubuntu 22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
         if-no-files-found: error
 
   build-linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Checkout

--- a/.github/workflows/install-linux.sh
+++ b/.github/workflows/install-linux.sh
@@ -12,6 +12,7 @@ python3 setup.py build_ext --inplace
 
 sudo apt-get update
 sudo apt-get install -y desktop-file-utils # for desktop-file-validate, used by pkg2appimage
+sudo apt-get install -y fuse # AppImages require FUSE to run
 
 # when PyInstaller collect libraries, it ignores libraries that are not found on the host.
 # Those missing libs prevent proper startup.


### PR DESCRIPTION
Ubuntu 20.04 runners are deprecated.
Ubuntu 22.04 does not have fuse installed, and it's required for appimage builds.