### PR TITLE
Replace depricated ndarray.tostring() with tobytes()

### DIFF
--- a/friture/spectrogram_image.py
+++ b/friture/spectrogram_image.py
@@ -117,7 +117,7 @@ class CanvasScaledSpectrogram(QtCore.QObject):
         self.last_write_time = last_data_time
 
     def colors_to_bytes(self, data):
-        return data.tostring()
+        return data.tobytes()
 
     # defined as a separate function so that it appears in the profiler
     # NOTE: QImage with a colormap is slower (by a factor of 2) than the custom


### PR DESCRIPTION
See https://numpy.org/doc/2.2/reference/generated/numpy.ndarray.tostring.html - it appears this was completely removed in the recent 2.3 numpy update, breaking friture's spectrograms

(hope you don't mind the extra line break GitHub's editor added at the end of the file)
