### PR TITLE
Fixed levels widget styling

### DIFF
--- a/friture/Levels.qml
+++ b/friture/Levels.qml
@@ -24,6 +24,7 @@ Rectangle {
         id: fontMetrics
         font.pointSize: 14
         font.bold: true
+        font.family: "monospace"
     }
 
     ColumnLayout {
@@ -38,6 +39,7 @@ Rectangle {
             text: level_view_model.two_channels ? "1: " + level_to_text(level_view_model.level_data_slow.level_max) + "<br />2: " + level_to_text(level_view_model.level_data_slow_2.level_max) : level_to_text(level_view_model.level_data_slow.level_max)
             font.pointSize: 14
             font.bold: true
+            font.family: "monospace"
             verticalAlignment: Text.AlignBottom
             horizontalAlignment: Text.AlignRight
             Layout.alignment: Qt.AlignBottom | Qt.AlignRight
@@ -60,6 +62,7 @@ Rectangle {
             text: level_view_model.two_channels ? "1: " + level_to_text(level_view_model.level_data_slow.level_rms) + "<br />2: " + level_to_text(level_view_model.level_data_slow_2.level_rms) : level_to_text(level_view_model.level_data_slow.level_rms)
             font.pointSize: 14
             font.bold: true
+            font.family: "monospace"
             verticalAlignment: Text.AlignBottom
             horizontalAlignment: Text.AlignRight
             Layout.alignment: Qt.AlignVCenter | Qt.AlignRight

--- a/friture/Levels.qml
+++ b/friture/Levels.qml
@@ -34,7 +34,7 @@ Rectangle {
 
         Text {
             id: peakValues
-            textFormat: Text.MarkdownText
+            textFormat: Text.StyledText
             text: level_view_model.two_channels ? "1: " + level_to_text(level_view_model.level_data_slow.level_max) + "<br />2: " + level_to_text(level_view_model.level_data_slow_2.level_max) : level_to_text(level_view_model.level_data_slow.level_max)
             font.pointSize: 14
             font.bold: true
@@ -56,7 +56,7 @@ Rectangle {
 
         Text {
             id: rmsValues
-            textFormat: Text.MarkdownText
+            textFormat: Text.StyledText
             text: level_view_model.two_channels ? "1: " + level_to_text(level_view_model.level_data_slow.level_rms) + "<br />2: " + level_to_text(level_view_model.level_data_slow_2.level_rms) : level_to_text(level_view_model.level_data_slow.level_rms)
             font.pointSize: 14
             font.bold: true
@@ -88,6 +88,6 @@ Rectangle {
             return "`-Inf`";
         }
 
-        return "`" + dB.toFixed(1) + "`";
+        return dB.toFixed(1);
     }
 }


### PR DESCRIPTION
Changed the text format from MarkdownText to StyledText and removed the inline code formatting. This fixes font size calculation and keeps the text styling and line break.