### PR TITLE
Friture now indentifies itself to Pipewire ALSA

### DIFF
--- a/friture/analyzer.py
+++ b/friture/analyzer.py
@@ -413,6 +413,9 @@ def main():
         logger.info("Adding the following to the Library paths: %s", pluginsPath)
         QApplication.addLibraryPath(pluginsPath)
 
+    if platform.system() == "Linux":
+        os.environ['PIPEWIRE_ALSA'] = '{ application.name = "Friture" }'
+
     # Splash screen
     pixmap = QPixmap(":/images/splash.png")
     splash = QSplashScreen(pixmap)


### PR DESCRIPTION
Linux systems using Pipewire ALSA now identifies Friture when listing audio streams as described in #255 

Old:
<img width="564" height="171" alt="image" src="https://github.com/user-attachments/assets/c5929d78-60f8-4961-ae05-4ee4cb7877f9" />

New:
<img width="539" height="147" alt="image" src="https://github.com/user-attachments/assets/ff98fc1c-85e9-4544-ae91-7daf5ae43964" />
