### PR TITLE
Added argparse and ability to disable splash screen

### DIFF
--- a/friture/analyzer.py
+++ b/friture/analyzer.py
@@ -20,6 +20,7 @@
 import sys
 import os
 import os.path
+import argparse
 import errno
 import platform
 import logging
@@ -345,6 +346,20 @@ class StreamToLogger(object):
 
 
 def main():
+    # parse command line arguments
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--python",
+        action="store_true",
+        help="Print data to friture.cprof")
+
+    parser.add_argument(
+        "--kcachegrind",
+        action="store_true")
+
+    program_arguments = parser.parse_args()
+
     # make the Python warnings go to Friture logger
     logging.captureWarnings(True)
 
@@ -426,15 +441,10 @@ def main():
 
     profile = "no"  # "python" or "kcachegrind" or anything else to disable
 
-    if len(sys.argv) > 1:
-        if sys.argv[1] == "--python":
-            profile = "python"
-        elif sys.argv[1] == "--kcachegrind":
-            profile = "kcachegrind"
-        elif sys.argv[1] == "--no":
-            profile = "no"
-        else:
-            logger.info("command-line arguments (%s) not recognized", sys.argv[1:])
+    if program_arguments.python:
+        profile = "python"
+    elif program_arguments.kcachegrind:
+        profile = "kcachegrind"
 
     return_code = 0
     if profile == "python":

--- a/friture/analyzer.py
+++ b/friture/analyzer.py
@@ -358,6 +358,11 @@ def main():
         "--kcachegrind",
         action="store_true")
 
+    parser.add_argument(
+        "--no-splash",
+        action="store_true",
+        help="Disable the splash screen on startup")
+
     program_arguments = parser.parse_args()
 
     # make the Python warnings go to Friture logger
@@ -429,15 +434,17 @@ def main():
         QApplication.addLibraryPath(pluginsPath)
 
     # Splash screen
-    pixmap = QPixmap(":/images/splash.png")
-    splash = QSplashScreen(pixmap)
-    splash.show()
-    splash.showMessage("Initializing the audio subsystem")
-    app.processEvents()
+    if not program_arguments.no_splash:
+        pixmap = QPixmap(":/images/splash.png")
+        splash = QSplashScreen(pixmap)
+        splash.show()
+        splash.showMessage("Initializing the audio subsystem")
+        app.processEvents()
 
     window = Friture()
     window.show()
-    splash.finish(window)
+    if not program_arguments.no_splash:
+        splash.finish(window)
 
     profile = "no"  # "python" or "kcachegrind" or anything else to disable
 

--- a/friture/analyzer.py
+++ b/friture/analyzer.py
@@ -363,7 +363,8 @@ def main():
         action="store_true",
         help="Disable the splash screen on startup")
 
-    program_arguments = parser.parse_args()
+    program_arguments, remaining_arguments = parser.parse_known_args()
+    remaining_arguments.insert(0, sys.argv[0])
 
     # make the Python warnings go to Friture logger
     logging.captureWarnings(True)
@@ -424,7 +425,7 @@ def main():
         except:
             logger.error("Could not set the app model ID. If the plaftorm is older than Windows 7, this is normal.")
 
-    app = QApplication(sys.argv)
+    app = QApplication(remaining_arguments)
 
     if platform.system() == "Darwin":
         logger.info("Applying Mac OS-specific setup")


### PR DESCRIPTION
Switched from using sys.argv to using argparse for the main command line arguments. If ./main.py -h is called, a argparse's helper is returned. If a command is recognised, the program consumes it. Remaining arguments are passed into QApplication. 

I also added a command line argument that optionally disables the splash screen on start up.