### PR TITLE
fix(levels): use a monospace font that works on all platforms

### DIFF
--- a/friture/Levels.qml
+++ b/friture/Levels.qml
@@ -9,7 +9,9 @@ Rectangle {
     color: systemPalette.window
 
     property var stateId
-    property LevelViewModel level_view_model: Store.dock_states[stateId]  
+    property LevelViewModel level_view_model: Store.dock_states[stateId]
+
+    property var fixedFont
 
     // parent here will be unset on exit
     height: parent ? parent.height : 0
@@ -24,7 +26,7 @@ Rectangle {
         id: fontMetrics
         font.pointSize: 14
         font.bold: true
-        font.family: "monospace"
+        font.family: fixedFont
     }
 
     ColumnLayout {
@@ -39,7 +41,7 @@ Rectangle {
             text: level_view_model.two_channels ? "1: " + level_to_text(level_view_model.level_data_slow.level_max) + "<br />2: " + level_to_text(level_view_model.level_data_slow_2.level_max) : level_to_text(level_view_model.level_data_slow.level_max)
             font.pointSize: 14
             font.bold: true
-            font.family: "monospace"
+            font.family: fixedFont
             verticalAlignment: Text.AlignBottom
             horizontalAlignment: Text.AlignRight
             Layout.alignment: Qt.AlignBottom | Qt.AlignRight
@@ -62,7 +64,7 @@ Rectangle {
             text: level_view_model.two_channels ? "1: " + level_to_text(level_view_model.level_data_slow.level_rms) + "<br />2: " + level_to_text(level_view_model.level_data_slow_2.level_rms) : level_to_text(level_view_model.level_data_slow.level_rms)
             font.pointSize: 14
             font.bold: true
-            font.family: "monospace"
+            font.family: fixedFont
             verticalAlignment: Text.AlignBottom
             horizontalAlignment: Text.AlignRight
             Layout.alignment: Qt.AlignVCenter | Qt.AlignRight

--- a/friture/levels.py
+++ b/friture/levels.py
@@ -22,6 +22,7 @@
 from PyQt5 import QtWidgets
 from PyQt5.QtQml import QQmlComponent
 from PyQt5.QtQuick import QQuickWindow # type: ignore
+from PyQt5.QtGui import QFontDatabase
 import numpy as np
 
 from friture.store import GetStore
@@ -56,8 +57,10 @@ class Levels_Widget(QtWidgets.QWidget):
         component = QQmlComponent(engine, qml_url("Levels.qml"), self)
         raise_if_error(component)
 
+        fixedFont = QFontDatabase.systemFont(QFontDatabase.FixedFont)
+
         engineContext = engine.rootContext()
-        initialProperties = {"parent": self.quickWindow.contentItem(), "stateId": state_id }
+        initialProperties = {"parent": self.quickWindow.contentItem(), "stateId": state_id, "fixedFont": fixedFont }
         self.qmlObject = component.createWithInitialProperties(initialProperties, engineContext)
         self.qmlObject.setParent(self.quickWindow)
 


### PR DESCRIPTION
https://github.com/tlecomte/friture/pull/338 changed to a 'monospace' font to fix the formatting of the levels. However, 'monospace' does not work on all platforms. On Windows, it falls back to Arial, which is not monospace.

The common workaround is to find the fixed font with Qt, and then pass it as a QML variable.

cc @Robin-K-Lynn 