### PR TITLE
feat(Qt): remove redundant QLayout

### DIFF
--- a/friture/PitchView.qml
+++ b/friture/PitchView.qml
@@ -1,61 +1,107 @@
-import QtQuick 2.9
+import QtQuick 2.15
 import QtQuick.Window 2.2
 import QtQuick.Layouts 1.15
+import QtQuick.Shapes 1.15
 import Friture 1.0
+import "plotItemColors.js" as PlotItemColors
 
-Rectangle {
-    id: pitch
-    SystemPalette { id: systemPalette; colorGroup: SystemPalette.Active }
-    color: systemPalette.window
+Item {
+    id: container
+    property var stateId
 
-    implicitWidth: pitchCol.implicitWidth
-    implicitHeight: parent ? parent.height : 0
+    // delay the load of the Plot until stateId has been set
+    Loader {
+        id: loader
+        anchors.fill: parent
+    }
 
-    property var pitch_view_model
+    onStateIdChanged: {
+        console.log("stateId changed: " + stateId)
+        loader.sourceComponent = plotComponent
+    }
 
-    ColumnLayout {
-        id: pitchCol
-        spacing: 0
+    Component {
+        id: plotComponent
 
-        FontMetrics {
-            id: fontMetrics
-            font.pointSize: 14
-            font.bold: true
-        }
+        Item {
+            Plot {
+                id: plot
+                scopedata: Store.dock_states[container.stateId]
 
-        Text {
-            id: note
-            text: pitch_view_model.note
-            textFormat: Text.PlainText
-            font.pointSize: 14
-            font.bold: true
-            rightPadding: 6
-            horizontalAlignment: Text.AlignRight
-            Layout.alignment: Qt.AlignTop | Qt.AlignRight
-            color: systemPalette.windowText
-        }
+                anchors.fill: null // override 'fill: parent' in Plot.qml
+                anchors.left: parent.left
+                anchors.right: pitchItem.left                
+                anchors.top: parent.top
+                anchors.bottom: parent.bottom
 
-        Text {
-            id: pitchHz
-            text: pitch_view_model.pitch
-            textFormat: Text.PlainText
-            font.pointSize: 14
-            font.bold: true
-            rightPadding: 6
-            horizontalAlignment: Text.AlignRight
-            Layout.preferredWidth: fontMetrics.boundingRect("000.0").width
-            Layout.alignment: Qt.AlignTop | Qt.AlignRight
-            color: systemPalette.windowText
-        }
+                Repeater {
+                    model: plot.scopedata.plot_items
 
-        Text {
-            id: pitchUnit
-            text: pitch_view_model.pitch_unit
-            textFormat: Text.PlainText
-            rightPadding: 6
-            horizontalAlignment: Text.AlignRight
-            Layout.alignment: Qt.AlignTop | Qt.AlignRight
-            color: systemPalette.windowText
+                    PlotCurve {
+                        anchors.fill: parent
+                        color: PlotItemColors.color(index)
+                        curve: modelData
+                    }
+                }
+            }
+
+            Rectangle {
+                id: pitchItem
+
+                implicitWidth: pitchCol.implicitWidth
+                implicitHeight: parent ? parent.height : 0
+
+                anchors.right: parent.right
+
+                SystemPalette { id: systemPalette; colorGroup: SystemPalette.Active }
+                color: systemPalette.window
+
+                ColumnLayout {
+                    id: pitchCol
+                    spacing: 0
+
+                    FontMetrics {
+                        id: fontMetrics
+                        font.pointSize: 14
+                        font.bold: true
+                    }
+
+                    Text {
+                        id: note
+                        text: plot.scopedata.note
+                        textFormat: Text.PlainText
+                        font.pointSize: 14
+                        font.bold: true
+                        rightPadding: 6
+                        horizontalAlignment: Text.AlignRight
+                        Layout.alignment: Qt.AlignTop | Qt.AlignRight
+                        color: systemPalette.windowText
+                    }
+
+                    Text {
+                        id: pitchHz
+                        text: plot.scopedata.pitch
+                        textFormat: Text.PlainText
+                        font.pointSize: 14
+                        font.bold: true
+                        rightPadding: 6
+                        horizontalAlignment: Text.AlignRight
+                        Layout.preferredWidth: fontMetrics.boundingRect("000.0").width
+                        Layout.alignment: Qt.AlignTop | Qt.AlignRight
+                        color: systemPalette.windowText
+                    }
+
+                    Text {
+                        id: pitchUnit
+                        text: plot.scopedata.pitch_unit
+                        textFormat: Text.PlainText
+                        rightPadding: 6
+                        horizontalAlignment: Text.AlignRight
+                        Layout.alignment: Qt.AlignTop | Qt.AlignRight
+                        color: systemPalette.windowText
+                    }
+                }
+            }
         }
     }
 }

--- a/friture/histplot.py
+++ b/friture/histplot.py
@@ -33,10 +33,10 @@ from friture.store import GetStore
 # The peak decay rates (magic goes here :).
 PEAK_DECAY_RATE = 1.0 - 3E-6
 
-class HistPlot(QtWidgets.QWidget):
+class HistPlot(QQuickWidget):
 
     def __init__(self, parent, engine):
-        super(HistPlot, self).__init__(parent)
+        super(HistPlot, self).__init__(engine, parent)
 
         self.logger = logging.getLogger(__name__)
 
@@ -73,27 +73,18 @@ class HistPlot(QtWidgets.QWidget):
         self.normHorizontalScaleTransform.setScale(fscales.Logarithmic)
         self._histplot_data.horizontal_axis.setScale(fscales.Logarithmic)
 
-        plotLayout = QtWidgets.QGridLayout(self)
-        plotLayout.setSpacing(0)
-        plotLayout.setContentsMargins(0, 0, 0, 0)
+        self.statusChanged.connect(self.on_status_changed)
+        self.setResizeMode(QQuickWidget.SizeRootObjectToView)
+        self.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
+        self.setSource(qml_url("HistPlot.qml"))
 
-        self.quickWidget = QQuickWidget(engine, self)
-        self.quickWidget.statusChanged.connect(self.on_status_changed)
-        self.quickWidget.setResizeMode(QQuickWidget.SizeRootObjectToView)
-        self.quickWidget.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
-        self.quickWidget.setSource(qml_url("HistPlot.qml"))
+        raise_if_error(self)
 
-        raise_if_error(self.quickWidget)
-
-        self.quickWidget.rootObject().setProperty("stateId", state_id)
-
-        plotLayout.addWidget(self.quickWidget)
-
-        self.setLayout(plotLayout)
+        self.rootObject().setProperty("stateId", state_id)
 
     def on_status_changed(self, status):
         if status == QQuickWidget.Error:
-            for error in self.quickWidget.errors():
+            for error in self.errors():
                 self.logger.error("QML error: " + error.toString())
 
     def setdata(self, fl, fh, fc, y):

--- a/friture/imageplot.py
+++ b/friture/imageplot.py
@@ -26,10 +26,10 @@ from friture.spectrogram_item_data import SpectrogramImageData
 from friture.store import GetStore
 from friture.pitch_tracker import format_frequency
 
-class ImagePlot(QtWidgets.QWidget):
+class ImagePlot(QQuickWidget):
 
     def __init__(self, parent, engine):
-        super(ImagePlot, self).__init__(parent)
+        super(ImagePlot, self).__init__(engine, parent)
 
         self.logger = logging.getLogger(__name__)
 
@@ -53,27 +53,18 @@ class ImagePlot(QtWidgets.QWidget):
         self._spectrogram_data.color_axis.setRange(-140, 0)
         self._spectrogram_data.show_color_axis = True
 
-        plotLayout = QtWidgets.QGridLayout(self)
-        plotLayout.setSpacing(0)
-        plotLayout.setContentsMargins(0, 0, 0, 0)
-
-        self.quickWidget = QQuickWidget(engine, self)
-        self.quickWidget.statusChanged.connect(self.on_status_changed)
-        self.quickWidget.setResizeMode(QQuickWidget.SizeRootObjectToView)
-        self.quickWidget.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
-        self.quickWidget.setSource(qml_url("ImagePlot.qml"))
+        self.statusChanged.connect(self.on_status_changed)
+        self.setResizeMode(QQuickWidget.SizeRootObjectToView)
+        self.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
+        self.setSource(qml_url("ImagePlot.qml"))
         
-        raise_if_error(self.quickWidget)
+        raise_if_error(self)
 
-        self.quickWidget.rootObject().setProperty("stateId", state_id)
-
-        plotLayout.addWidget(self.quickWidget)
-
-        self.setLayout(plotLayout)
+        self.rootObject().setProperty("stateId", state_id)
 
     def on_status_changed(self, status):
         if status == QQuickWidget.Error:
-            for error in self.quickWidget.errors():
+            for error in self.errors():
                 self.logger.error("QML error: " + error.toString())
 
     def push(self, data, last_data_time):

--- a/friture/longlevels.py
+++ b/friture/longlevels.py
@@ -93,14 +93,12 @@ class Subsampler:
         return x_dec
 
 
-class LongLevelWidget(QtWidgets.QWidget):
+class LongLevelWidget(QQuickWidget):
 
     def __init__(self, parent, engine):
-        super().__init__(parent)
+        super().__init__(engine, parent)
 
         self.logger = logging.getLogger(__name__)
-
-        self.setObjectName("LongLevels_Widget")
 
         store = GetStore()
         self._long_levels_data = Scope_Data(store)
@@ -116,22 +114,14 @@ class LongLevelWidget(QtWidgets.QWidget):
         self._long_levels_data.horizontal_axis.name = "Time (sec)"
         self._long_levels_data.horizontal_axis.setTrackerFormatter(lambda x: "%#.3g sec" % (x))
 
-        self.setObjectName("Scope_Widget")
-        self.gridLayout = QtWidgets.QGridLayout(self)
-        self.gridLayout.setObjectName("gridLayout")
-        self.gridLayout.setContentsMargins(2, 2, 2, 2)
-
-        self.quickWidget = QQuickWidget(engine, self)
-        self.quickWidget.statusChanged.connect(self.on_status_changed)
-        self.quickWidget.setResizeMode(QQuickWidget.SizeRootObjectToView)
-        self.quickWidget.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
-        self.quickWidget.setSource(qml_url("Scope.qml"))
+        self.statusChanged.connect(self.on_status_changed)
+        self.setResizeMode(QQuickWidget.SizeRootObjectToView)
+        self.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
+        self.setSource(qml_url("Scope.qml"))
         
-        raise_if_error(self.quickWidget)
+        raise_if_error(self)
 
-        self.quickWidget.rootObject().setProperty("stateId", state_id)
-
-        self.gridLayout.addWidget(self.quickWidget, 0, 0, 1, 1)
+        self.rootObject().setProperty("stateId", state_id)
 
         self.level_min = DEFAULT_LEVEL_MIN
         self.level_max = DEFAULT_LEVEL_MAX
@@ -214,7 +204,7 @@ class LongLevelWidget(QtWidgets.QWidget):
 
     def on_status_changed(self, status):
         if status == QQuickWidget.Error:
-            for error in self.quickWidget.errors():
+            for error in self.errors():
                 self.logger.error("QML error: " + error.toString())
 
     # method

--- a/friture/pitch_tracker_data.py
+++ b/friture/pitch_tracker_data.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2024 Celeste Sinéad
+
+# This file is part of Friture.
+#
+# Friture is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as published by
+# the Free Software Foundation.
+#
+# Friture is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Friture.  If not, see <http://www.gnu.org/licenses/>.
+
+from PyQt5 import QtCore
+from PyQt5.QtCore import pyqtProperty
+import numpy as np
+
+from friture.scope_data import Scope_Data
+
+def frequency_to_note(freq: float) -> str:
+    if np.isnan(freq) or freq <= 0:
+        return ""
+    # number of semitones from C4
+    # A4 = 440Hz and is 9 semitones above C4
+    semitone = round(np.log2(freq/440) * 12) + 9
+    octave = int(np.floor(semitone / 12)) + 4
+    notes = ["C", "C♯", "D", "D♯", "E", "F", "F♯", "G", "G♯", "A", "A♯", "B"]
+    return f'{notes[semitone % 12]}{octave}'
+
+def format_frequency(freq: float) -> str:
+    if freq < 1000:
+        return f'{freq:.0f} Hz ({frequency_to_note(freq)})'
+    else:
+        return f'{freq/1000:.1f} kHz ({frequency_to_note(freq)})'
+
+class PitchTracker_Data(Scope_Data):
+
+    pitch_changed = QtCore.pyqtSignal(float)
+
+    def __init__(self, parent: QtCore.QObject):
+        super().__init__(parent)
+        self._pitch = 0.0
+
+    @pyqtProperty(str, notify=pitch_changed)
+    def pitch(self) -> str:
+        if not self._pitch or np.isnan(self._pitch):
+            return '--'
+        elif self._pitch < 1000:
+            return f"{self._pitch:.0f}"
+        else:
+            return f"{self._pitch/1000:.2f}"
+
+    @pitch.setter # type: ignore
+    def pitch(self, pitch: float):
+        self._pitch = pitch
+        self.pitch_changed.emit(pitch)
+
+    @pyqtProperty(str, notify=pitch_changed) # type: ignore
+    def pitch_unit(self) -> str:
+        if self._pitch >= 1000.0:
+            return "kHz"
+        else:
+            return "Hz"
+
+    @pyqtProperty(str, notify=pitch_changed) # type: ignore
+    def note(self) -> str:
+        if not self._pitch or np.isnan(self._pitch):
+            return '--'
+        else:
+            return frequency_to_note(self._pitch)

--- a/friture/playback/control.py
+++ b/friture/playback/control.py
@@ -21,8 +21,8 @@ import logging
 from typing import Any
 
 from PyQt5.QtCore import pyqtSignal
-from PyQt5.QtGui import QColor, QPalette
-from PyQt5.QtWidgets import QGridLayout, QSizePolicy, QWidget
+from PyQt5.QtGui import QPalette
+from PyQt5.QtWidgets import QSizePolicy, QWidget
 from PyQt5.QtQml import QQmlEngine
 from PyQt5.QtQuickWidgets import QQuickWidget
 
@@ -31,26 +31,21 @@ from friture.playback.player import Player
 
 logger = logging.getLogger(__name__)
 
-class PlaybackControlWidget(QWidget):
+class PlaybackControlWidget(QQuickWidget):
     recording_toggled = pyqtSignal()
 
     def __init__(self, parent: QWidget, engine: QQmlEngine, player: Player):
-        super().__init__(parent)
-        self.widget = QQuickWidget(engine, self)
-        self.widget.statusChanged.connect(self.on_status_changed)
-        self.widget.setResizeMode(QQuickWidget.SizeRootObjectToView)
-        self.widget.setSizePolicy(
+        super().__init__(engine, parent)
+        self.statusChanged.connect(self.on_status_changed)
+        self.setResizeMode(QQuickWidget.SizeRootObjectToView)
+        self.setSizePolicy(
             QSizePolicy.Expanding, QSizePolicy.Preferred
         )
-        self.widget.setClearColor(self.palette().color(QPalette.Window))
-        self.widget.setSource(qml_url("playback/Control.qml"))
-        raise_if_error(self.widget)
+        self.setClearColor(self.palette().color(QPalette.Window))
+        self.setSource(qml_url("playback/Control.qml"))
+        raise_if_error(self)
 
-        layout = QGridLayout(self)
-        layout.addWidget(self.widget)
-        self.setLayout(layout)
-
-        self.root: Any = self.widget.rootObject()
+        self.root: Any = self.rootObject()
         self.root.stopClicked.connect(self.on_stopped)
         self.root.recordClicked.connect(self.on_record)
         self.root.playClicked.connect(self.on_played)
@@ -73,7 +68,7 @@ class PlaybackControlWidget(QWidget):
 
     def on_status_changed(self, status: QQuickWidget.Status) -> None:
         if status == QQuickWidget.Error:
-            for error in self.widget.errors():
+            for error in self.errors():
                 logger.error("QML error: " + error.toString())
 
     def on_stopped(self) -> None:

--- a/friture/scope.py
+++ b/friture/scope.py
@@ -33,10 +33,10 @@ from friture.qml_tools import qml_url, raise_if_error
 SMOOTH_DISPLAY_TIMER_PERIOD_MS = 25
 DEFAULT_TIMERANGE = 2 * SMOOTH_DISPLAY_TIMER_PERIOD_MS
 
-class Scope_Widget(QtWidgets.QWidget):
+class Scope_Widget(QQuickWidget):
 
     def __init__(self, parent, engine):
-        super().__init__(parent)
+        super().__init__(engine, parent)
 
         self.logger = logging.getLogger(__name__)
 
@@ -59,21 +59,13 @@ class Scope_Widget(QtWidgets.QWidget):
         self._scope_data.horizontal_axis.name = "Time (ms)"
         self._scope_data.horizontal_axis.setTrackerFormatter(lambda x: "%#.3g ms" % (x))
 
-        self.setObjectName("Scope_Widget")
-        self.gridLayout = QtWidgets.QGridLayout(self)
-        self.gridLayout.setObjectName("gridLayout")
-        self.gridLayout.setContentsMargins(2, 2, 2, 2)
-
-        self.quickWidget = QQuickWidget(engine, self)
-        self.quickWidget.statusChanged.connect(self.on_status_changed)
-        self.quickWidget.setResizeMode(QQuickWidget.SizeRootObjectToView)
-        self.quickWidget.setSource(qml_url("Scope.qml"))
+        self.statusChanged.connect(self.on_status_changed)
+        self.setResizeMode(QQuickWidget.SizeRootObjectToView)
+        self.setSource(qml_url("Scope.qml"))
         
-        raise_if_error(self.quickWidget)
+        raise_if_error(self)
 
-        self.quickWidget.rootObject().setProperty("stateId", state_id)
-
-        self.gridLayout.addWidget(self.quickWidget)
+        self.rootObject().setProperty("stateId", state_id)
 
         self.settings_dialog = Scope_Settings_Dialog(self)
 
@@ -85,7 +77,7 @@ class Scope_Widget(QtWidgets.QWidget):
 
     def on_status_changed(self, status):
         if status == QQuickWidget.Error:
-            for error in self.quickWidget.errors():
+            for error in self.errors():
                 self.logger.error("QML error: " + error.toString())
 
     # method

--- a/friture/spectrumPlotWidget.py
+++ b/friture/spectrumPlotWidget.py
@@ -29,10 +29,10 @@ class Baseline(Enum):
     DATA_ZERO = 2
 
 
-class SpectrumPlotWidget(QtWidgets.QWidget):
+class SpectrumPlotWidget(QQuickWidget):
 
     def __init__(self, parent, engine):
-        super(SpectrumPlotWidget, self).__init__(parent)
+        super(SpectrumPlotWidget, self).__init__(engine, parent)
 
         self.logger = logging.getLogger(__name__)
 
@@ -68,29 +68,20 @@ class SpectrumPlotWidget(QtWidgets.QWidget):
         self.normVerticalScaleTransform = CoordinateTransform(0, 1, 1, 0, 0)
         self.normHorizontalScaleTransform = CoordinateTransform(0, 22000, 1, 0, 0)
 
-        plotLayout = QtWidgets.QGridLayout(self)
-        plotLayout.setSpacing(0)
-        plotLayout.setContentsMargins(0, 0, 0, 0)
-
-        self.quickWidget = QQuickWidget(engine, self)
-        self.quickWidget.statusChanged.connect(self.on_status_changed)
-        self.quickWidget.setResizeMode(QQuickWidget.SizeRootObjectToView)
-        self.quickWidget.setSizePolicy(
+        self.statusChanged.connect(self.on_status_changed)
+        self.setResizeMode(QQuickWidget.SizeRootObjectToView)
+        self.setSizePolicy(
             QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding
         )
-        self.quickWidget.setSource(qml_url("Spectrum.qml"))
+        self.setSource(qml_url("Spectrum.qml"))
 
-        raise_if_error(self.quickWidget)
+        raise_if_error(self)
 
-        self.quickWidget.rootObject().setProperty("stateId", state_id)
-
-        plotLayout.addWidget(self.quickWidget)
-
-        self.setLayout(plotLayout)
+        self.rootObject().setProperty("stateId", state_id)
 
     def on_status_changed(self, status):
         if status == QQuickWidget.Error:
-            for error in self.quickWidget.errors():
+            for error in self.errors():
                 self.logger.error("QML error: " + error.toString())
 
     def setfreqscale(self, scale):

--- a/friture/widgetdict.py
+++ b/friture/widgetdict.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Friture.  If not, see <http://www.gnu.org/licenses/>.
 
-from friture.levels import Levels_Widget
 from friture.spectrum import Spectrum_Widget
 from friture.spectrogram import Spectrogram_Widget
 from friture.octavespectrum import OctaveSpectrum_Widget


### PR DESCRIPTION
Remove redundant QLayout instances in each visualization widget.

Each visualization widget is implemented as a QML object. At some point in the future, we want to make Friture a full QML app, instead of the current QML-in-QWidget state. Removing the layouts is one small step in this direction.

For the Pitch Tracker, that involves migrating to a new view that contains both the scope and the pitch view.