### PR TITLE
feat(QML): all widgets are now QML components

### DIFF
--- a/friture.spec
+++ b/friture.spec
@@ -82,7 +82,7 @@ if platform.system() == "Windows":
 a = Analysis(['main.py'],
              pathex=pathex,
              binaries=[],
-             datas= [('friture/*.qml', '.' ), ('friture/playback/*.qml', 'playback' ), ('friture/*.js', '.' )],
+             datas= [('friture/*.qml', '.' ), ('friture/playback/*.qml', 'playback' ), ('friture/generators/*.qml', 'generators' ), ('friture/*.js', '.' )],
              hiddenimports=[],
              hookspath=["installer/pyinstaller-hooks"], # our custom hooks for python-sounddevice
              runtime_hooks=[],

--- a/friture/DelayEstimator.qml
+++ b/friture/DelayEstimator.qml
@@ -1,0 +1,63 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Rectangle {
+    id: root
+    required property var viewModel
+    required property string fixedFont
+
+    SystemPalette { id: systemPalette; colorGroup: SystemPalette.Active }
+    color: systemPalette.window
+    anchors.fill: parent
+
+    Column {
+        spacing: 8
+        anchors.fill: parent
+        anchors.margins: 12
+
+        Row {
+            spacing: 8
+            Label {
+                text: qsTr("Delay:")
+                font.pointSize: 14
+                color: systemPalette.windowText
+            }
+            Label {
+                text: viewModel.delay
+                font.pointSize: 14
+                font.bold: true
+                color: systemPalette.windowText
+            }
+        }
+        Row {
+            spacing: 8
+            Label {
+                text: qsTr("Confidence:")
+                color: systemPalette.windowText
+            }
+            Label {
+                id: correlationLabel
+                text: viewModel.correlation
+                color: systemPalette.windowText
+            }
+        }
+        Row {
+            spacing: 8
+            Label {
+                text: qsTr("Polarity:")
+                color: systemPalette.windowText
+            }
+            Label {
+                text: viewModel.polarity
+                font.pointSize: 14
+                font.bold: true
+                color: systemPalette.windowText
+            }
+        }
+        Label {
+            text: viewModel.channel_info
+            wrapMode: Text.WordWrap
+            color: systemPalette.windowText
+        }
+    }
+}

--- a/friture/Generator.qml
+++ b/friture/Generator.qml
@@ -1,0 +1,62 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import QtQuick.Dialogs 1.3
+import QtQml 2.15
+import "./generators"
+
+Rectangle {
+    id: generatorRoot
+    required property var viewModel
+    required property string fixedFont
+
+    SystemPalette { id: systemPalette; colorGroup: SystemPalette.Active }
+    color: systemPalette.window
+    anchors.fill: parent
+
+    ColumnLayout {
+        anchors.top: parent.top
+        anchors.left: parent.left
+        spacing: 12
+
+        ComboBox {
+            model: viewModel.generatorNames
+            currentIndex: viewModel.generatorIndex
+            onCurrentIndexChanged: viewModel.generatorIndex = currentIndex
+        }
+
+        Button {
+            id: startStopButton
+            text: viewModel.isPlaying ? qsTr("Stop") : qsTr("Start")
+            checkable: true
+            checked: viewModel.isPlaying
+            onCheckedChanged: viewModel.isPlaying = checked
+            icon.source: viewModel.isPlaying ? "qrc:/images-src/stop.svg" : "qrc:/images-src/start.svg"
+        }
+
+        SineSettings {
+            viewModel: generatorRoot.viewModel.sineGenerator
+            visible: generatorRoot.viewModel.generatorIndex === 0
+        }
+
+        WhiteSettings {
+            viewModel: generatorRoot.viewModel.whiteGenerator
+            visible: generatorRoot.viewModel.generatorIndex === 1
+        }
+
+        PinkSettings {
+            viewModel: generatorRoot.viewModel.pinkGenerator
+            visible: generatorRoot.viewModel.generatorIndex === 2
+        }
+
+        SweepSettings {
+            viewModel: generatorRoot.viewModel.sweepGenerator
+            visible: generatorRoot.viewModel.generatorIndex === 3
+        }
+
+        BurstSettings {
+            viewModel: generatorRoot.viewModel.burstGenerator
+            visible: generatorRoot.viewModel.generatorIndex === 4
+        }
+    }
+}

--- a/friture/HistPlot.qml
+++ b/friture/HistPlot.qml
@@ -3,71 +3,53 @@ import QtQuick.Window 2.2
 import QtQuick.Layouts 1.15
 import QtQuick.Shapes 1.15
 import Friture 1.0
-import "plotItemColors.js" as PlotItemColors
 
-Item {
-    id: container
-    property var stateId
+Plot {
+    required property var viewModel
+    required property string fixedFont
 
-    SystemPalette { id: systemPalette; colorGroup: SystemPalette.Active }
+    scopedata: viewModel
 
-    // delay the load of the Plot until stateId has been set
-    Loader {
-        id: loader
+    Repeater {
+        model: scopedata.plot_items
+
+        PlotFilledCurve {
+            anchors.fill: parent
+            curve: modelData
+        }
+    }    
+
+    Item {
+        visible: scopedata.bar_labels_x_distance * parent.width > fontMetrics.boundingRect("100").height
         anchors.fill: parent
-    }
 
-    onStateIdChanged: {
-        console.log("stateId changed: " + stateId)
-        loader.sourceComponent = plotComponent
-    }
+        FontMetrics {
+            id: fontMetrics
+        }
 
-    Component {
-        id: plotComponent
-
-        Plot {
-            scopedata: Store.dock_states[container.stateId]
-
-            Repeater {
-                model: scopedata.plot_items
-
-                PlotFilledCurve {
-                    anchors.fill: parent
-                    curve: modelData
-                }
-            }    
+        SystemPalette { id: systemPalette; colorGroup: SystemPalette.Active }
+    
+        Repeater {
+            model: scopedata.barLabels
 
             Item {
-                visible: scopedata.bar_labels_x_distance * parent.width > fontMetrics.boundingRect("100").height
-                anchors.fill: parent
+                x: modelData.x * parent.width - barLabel.height / 2
+                y: Math.max(4, Math.min(modelData.y * parent.height + 4, parent.height - barLabel.width - 4))
 
-                FontMetrics {
-                    id: fontMetrics
+                // width vs. height: childrenRect doesn't take transformations into account.
+                // https://bugreports.qt-project.org/browse/QTBUG-38953
+                implicitWidth: barLabel.height
+                implicitHeight: barLabel.width
+
+                Text {
+                    id: barLabel
+                    text: modelData.unscaled_x
+                    rotation: 270
+                    transformOrigin: Item.Center
+                    anchors.centerIn: parent
+                    color: modelData.y * parent.parent.height + 4 > parent.parent.height - barLabel.width - 4 ? systemPalette.windowText : systemPalette.base
                 }
-            
-                Repeater {
-                    model: scopedata.barLabels
-
-                    Item {
-                        x: modelData.x * parent.width - barLabel.height / 2
-                        y: Math.max(4, Math.min(modelData.y * parent.height + 4, parent.height - barLabel.width - 4))
-
-                        // width vs. height: childrenRect doesn't take transformations into account.
-                        // https://bugreports.qt-project.org/browse/QTBUG-38953
-                        implicitWidth: barLabel.height
-                        implicitHeight: barLabel.width
-
-                        Text {
-                            id: barLabel
-                            text: modelData.unscaled_x
-                            rotation: 270
-                            transformOrigin: Item.Center
-                            anchors.centerIn: parent
-                            color: modelData.y * parent.parent.height + 4 > parent.parent.height - barLabel.width - 4 ? systemPalette.windowText : systemPalette.base
-                        }
-                    }               
-                }
-            }
-        }  
+            }               
+        }
     }
 }

--- a/friture/ImagePlot.qml
+++ b/friture/ImagePlot.qml
@@ -3,37 +3,19 @@ import QtQuick.Window 2.2
 import QtQuick.Layouts 1.15
 import QtQuick.Shapes 1.15
 import Friture 1.0
-import "plotItemColors.js" as PlotItemColors
 
-Item {
-    id: container
-    property var stateId
+Plot {
+    required property var viewModel
+    required property string fixedFont
 
-    // delay the load of the Plot until stateId has been set
-    Loader {
-        id: loader
-        anchors.fill: parent
-    }
+    scopedata: viewModel
 
-    onStateIdChanged: {
-        console.log("stateId changed: " + stateId)
-        loader.sourceComponent = plotComponent
-    }
+    Repeater {
+        model: scopedata.plot_items
 
-    Component {
-        id: plotComponent
-
-        Plot {
-            scopedata: Store.dock_states[container.stateId]
-
-            Repeater {
-                model: scopedata.plot_items
-
-                SpectrogramItem {
-                    anchors.fill: parent
-                    curve: modelData
-                }
-            }
-        }  
+        SpectrogramItem {
+            anchors.fill: parent
+            curve: modelData
+        }
     }
 }

--- a/friture/Levels.qml
+++ b/friture/Levels.qml
@@ -11,7 +11,7 @@ Rectangle {
     property var stateId
     property LevelViewModel level_view_model: Store.dock_states[stateId]
 
-    property var fixedFont
+    property string fixedFont
 
     // parent here will be unset on exit
     height: parent ? parent.height : 0

--- a/friture/PitchView.qml
+++ b/friture/PitchView.qml
@@ -7,100 +7,84 @@ import "plotItemColors.js" as PlotItemColors
 
 Item {
     id: container
-    property var stateId
+    required property var viewModel
+    required property string fixedFont
 
-    // delay the load of the Plot until stateId has been set
-    Loader {
-        id: loader
-        anchors.fill: parent
+    Plot {
+        id: plot
+        scopedata: viewModel
+
+        anchors.fill: null // override 'fill: parent' in Plot.qml
+        anchors.left: parent.left
+        anchors.right: pitchItem.left                
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+
+        Repeater {
+            model: plot.scopedata.plot_items
+
+            PlotCurve {
+                anchors.fill: parent
+                color: PlotItemColors.color(index)
+                curve: modelData
+            }
+        }
     }
 
-    onStateIdChanged: {
-        console.log("stateId changed: " + stateId)
-        loader.sourceComponent = plotComponent
-    }
+    Rectangle {
+        id: pitchItem
 
-    Component {
-        id: plotComponent
+        implicitWidth: pitchCol.implicitWidth
+        implicitHeight: parent ? parent.height : 0
 
-        Item {
-            Plot {
-                id: plot
-                scopedata: Store.dock_states[container.stateId]
+        anchors.right: parent.right
 
-                anchors.fill: null // override 'fill: parent' in Plot.qml
-                anchors.left: parent.left
-                anchors.right: pitchItem.left                
-                anchors.top: parent.top
-                anchors.bottom: parent.bottom
+        SystemPalette { id: systemPalette; colorGroup: SystemPalette.Active }
+        color: systemPalette.window
 
-                Repeater {
-                    model: plot.scopedata.plot_items
+        ColumnLayout {
+            id: pitchCol
+            spacing: 0
 
-                    PlotCurve {
-                        anchors.fill: parent
-                        color: PlotItemColors.color(index)
-                        curve: modelData
-                    }
-                }
+            FontMetrics {
+                id: fontMetrics
+                font.pointSize: 14
+                font.bold: true
             }
 
-            Rectangle {
-                id: pitchItem
+            Text {
+                id: note
+                text: plot.scopedata.note
+                textFormat: Text.PlainText
+                font.pointSize: 14
+                font.bold: true
+                rightPadding: 6
+                horizontalAlignment: Text.AlignRight
+                Layout.alignment: Qt.AlignTop | Qt.AlignRight
+                color: systemPalette.windowText
+            }
 
-                implicitWidth: pitchCol.implicitWidth
-                implicitHeight: parent ? parent.height : 0
+            Text {
+                id: pitchHz
+                text: plot.scopedata.pitch
+                textFormat: Text.PlainText
+                font.pointSize: 14
+                font.bold: true
+                rightPadding: 6
+                horizontalAlignment: Text.AlignRight
+                Layout.preferredWidth: fontMetrics.boundingRect("000.0").width
+                Layout.alignment: Qt.AlignTop | Qt.AlignRight
+                color: systemPalette.windowText
+            }
 
-                anchors.right: parent.right
-
-                SystemPalette { id: systemPalette; colorGroup: SystemPalette.Active }
-                color: systemPalette.window
-
-                ColumnLayout {
-                    id: pitchCol
-                    spacing: 0
-
-                    FontMetrics {
-                        id: fontMetrics
-                        font.pointSize: 14
-                        font.bold: true
-                    }
-
-                    Text {
-                        id: note
-                        text: plot.scopedata.note
-                        textFormat: Text.PlainText
-                        font.pointSize: 14
-                        font.bold: true
-                        rightPadding: 6
-                        horizontalAlignment: Text.AlignRight
-                        Layout.alignment: Qt.AlignTop | Qt.AlignRight
-                        color: systemPalette.windowText
-                    }
-
-                    Text {
-                        id: pitchHz
-                        text: plot.scopedata.pitch
-                        textFormat: Text.PlainText
-                        font.pointSize: 14
-                        font.bold: true
-                        rightPadding: 6
-                        horizontalAlignment: Text.AlignRight
-                        Layout.preferredWidth: fontMetrics.boundingRect("000.0").width
-                        Layout.alignment: Qt.AlignTop | Qt.AlignRight
-                        color: systemPalette.windowText
-                    }
-
-                    Text {
-                        id: pitchUnit
-                        text: plot.scopedata.pitch_unit
-                        textFormat: Text.PlainText
-                        rightPadding: 6
-                        horizontalAlignment: Text.AlignRight
-                        Layout.alignment: Qt.AlignTop | Qt.AlignRight
-                        color: systemPalette.windowText
-                    }
-                }
+            Text {
+                id: pitchUnit
+                text: plot.scopedata.pitch_unit
+                textFormat: Text.PlainText
+                rightPadding: 6
+                horizontalAlignment: Text.AlignRight
+                Layout.alignment: Qt.AlignTop | Qt.AlignRight
+                color: systemPalette.windowText
             }
         }
     }

--- a/friture/Scope.qml
+++ b/friture/Scope.qml
@@ -5,35 +5,19 @@ import QtQuick.Shapes 1.15
 import Friture 1.0
 import "plotItemColors.js" as PlotItemColors
 
-Item {
-    id: container
-    property var stateId
+Plot {
+    required property var viewModel
+    required property string fixedFont
 
-    // delay the load of the Plot until stateId has been set
-    Loader {
-        id: loader
-        anchors.fill: parent
-    }
+    scopedata: viewModel
 
-    onStateIdChanged: {
-        console.log("stateId changed: " + stateId)
-        loader.sourceComponent = plotComponent
-    }
+    Repeater {
+        model: scopedata.plot_items
 
-    Component {
-        id: plotComponent
-        Plot {
-            scopedata: Store.dock_states[container.stateId]
-
-            Repeater {
-                model: scopedata.plot_items
-
-                PlotCurve {
-                    anchors.fill: parent
-                    color: PlotItemColors.color(index)
-                    curve: modelData
-                }
-            }
+        PlotCurve {
+            anchors.fill: parent
+            color: PlotItemColors.color(index)
+            curve: modelData
         }
     }
 }

--- a/friture/Spectrum.qml
+++ b/friture/Spectrum.qml
@@ -4,54 +4,38 @@ import QtQuick.Layouts 1.15
 import QtQuick.Shapes 1.15
 import Friture 1.0
 
-Item {
-    id: container
-    property var stateId
+Plot {
+    required property var viewModel
+    required property string fixedFont
 
-    // delay the load of the Plot until stateId has been set
-    Loader {
-        id: loader
+    scopedata: viewModel
+
+    Repeater {
+        model: scopedata.plot_items
+
+        PlotFilledCurve {
+            anchors.fill: parent
+            curve: modelData
+        }
+    }
+
+    Column {
         anchors.fill: parent
-    }
+        spacing: 0
+        FrequencyTracker {
+            visible: scopedata.showFrequencyTracker
+            anchors.left: parent.left
+            anchors.right: parent.right
+            fmaxValue: scopedata.fmaxValue
+            fmaxLogicalValue: scopedata.fmaxLogicalValue
+        }
 
-    onStateIdChanged: {
-        console.log("stateId changed: " + stateId)
-        loader.sourceComponent = plotComponent
-    }
-
-    Component {
-        id: plotComponent
-        Plot {
-            scopedata: Store.dock_states[container.stateId]
-
-            Repeater {
-                model: scopedata.plot_items
-
-                PlotFilledCurve {
-                    anchors.fill: parent
-                    curve: modelData
-                }
-            }
-
-            Column {
-                anchors.fill: parent
-                spacing: 0
-                FrequencyTracker {
-                    visible: scopedata.showFrequencyTracker
-                    anchors.left: parent.left
-                    anchors.right: parent.right
-                    fmaxValue: scopedata.fmaxValue
-                    fmaxLogicalValue: scopedata.fmaxLogicalValue
-                }
-
-                FrequencyTracker {
-                    visible: scopedata.showPitchTracker
-                    anchors.left: parent.left
-                    anchors.right: parent.right
-                    fmaxValue: scopedata.fpitchDisplayText
-                    fmaxLogicalValue: scopedata.fpitchValue
-                }
-            }
+        FrequencyTracker {
+            visible: scopedata.showPitchTracker
+            anchors.left: parent.left
+            anchors.right: parent.right
+            fmaxValue: scopedata.fpitchDisplayText
+            fmaxLogicalValue: scopedata.fpitchValue
         }
     }
 }

--- a/friture/analyzer.py
+++ b/friture/analyzer.py
@@ -62,6 +62,11 @@ from friture.spectrum_data import Spectrum_Data
 from friture.plotFilledCurve import PlotFilledCurve
 from friture.filled_curve import FilledCurve
 from friture.qml_tools import qml_url
+from friture.generators.sine import Sine_Generator_Settings_View_Model
+from friture.generators.white import White_Generator_Settings_View_Model
+from friture.generators.pink import Pink_Generator_Settings_View_Model
+from friture.generators.sweep import Sweep_Generator_Settings_View_Model
+from friture.generators.burst import Burst_Generator_Settings_View_Model
 
 # the display timer could be made faster when the processing
 # power allows it, firing down to every 10 ms
@@ -110,6 +115,12 @@ class Friture(QMainWindow, ):
         qmlRegisterType(SpectrogramImageData, 'Friture', 1, 0, 'SpectrogramImageData')
         qmlRegisterType(ColorBar, 'Friture', 1, 0, 'ColorBar')
         qmlRegisterType(Tick, 'Friture', 1, 0, 'Tick')
+        qmlRegisterType(Burst_Generator_Settings_View_Model, 'Friture', 1, 0, 'Burst_Generator_Settings_View_Model')
+        qmlRegisterType(Pink_Generator_Settings_View_Model, 'Friture', 1, 0, 'Pink_Generator_Settings_View_Model')
+        qmlRegisterType(White_Generator_Settings_View_Model, 'Friture', 1, 0, 'White_Generator_Settings_View_Model')
+        qmlRegisterType(Sweep_Generator_Settings_View_Model, 'Friture', 1, 0, 'Sweep_Generator_Settings_View_Model')
+        qmlRegisterType(Sine_Generator_Settings_View_Model, 'Friture', 1, 0, 'Sine_Generator_Settings_View_Model')
+
         qmlRegisterSingletonType(Store, 'Friture', 1, 0, 'Store', lambda engine, script_engine: GetStore())
 
         # Setup the user interface
@@ -442,6 +453,11 @@ def main():
     if platform.system() == "Linux":
         if "PIPEWIRE_ALSA" not in os.environ:
             os.environ['PIPEWIRE_ALSA'] = '{ application.name = "Friture" }'
+
+    # Set the style for Qt Quick Controls
+    # We choose the Fusion style as it is a desktop-oriented style
+    # It uses the standard system palettes to provide colors that match the desktop environment.
+    os.environ["QT_QUICK_CONTROLS_STYLE"] = "Fusion"
 
     # Splash screen
     if not program_arguments.no_splash:

--- a/friture/delay_estimator_view_model.py
+++ b/friture/delay_estimator_view_model.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2009 Timothée Lecomte
+
+# This file is part of Friture.
+#
+# Friture is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as published by
+# the Free Software Foundation.
+#
+# Friture is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Friture.  If not, see <http://www.gnu.org/licenses/>.
+
+from PyQt5 import QtCore
+
+class Delay_Estimator_View_Model(QtCore.QObject):
+    delayChanged = QtCore.pyqtSignal(str)
+    correlationChanged = QtCore.pyqtSignal(str)
+    polarityChanged = QtCore.pyqtSignal(str)
+    channelInfoChanged = QtCore.pyqtSignal(str)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._delay = ""
+        self._correlation = ""
+        self._polarity = ""
+        self._channel_info = ""
+
+    @QtCore.pyqtProperty(str, notify=delayChanged)
+    def delay(self):
+        return self._delay
+
+    @delay.setter # type: ignore
+    def delay(self, value):
+        if self._delay != value:
+            self._delay = value
+            self.delayChanged.emit(value)
+
+    @QtCore.pyqtProperty(str, notify=correlationChanged)
+    def correlation(self):
+        return self._correlation
+
+    @correlation.setter # type: ignore
+    def correlation(self, value):
+        if self._correlation != value:
+            self._correlation = value
+            self.correlationChanged.emit(value)
+
+    @QtCore.pyqtProperty(str, notify=polarityChanged)
+    def polarity(self):
+        return self._polarity
+
+    @polarity.setter # type: ignore
+    def polarity(self, value):
+        if self._polarity != value:
+            self._polarity = value
+            self.polarityChanged.emit(value)
+
+    @QtCore.pyqtProperty(str, notify=channelInfoChanged)
+    def channel_info(self):
+        return self._channel_info
+
+    @channel_info.setter # type: ignore
+    def channel_info(self, value):
+        if self._channel_info != value:
+            self._channel_info = value
+            self.channelInfoChanged.emit(value)

--- a/friture/dockmanager.py
+++ b/friture/dockmanager.py
@@ -64,7 +64,6 @@ class DockManager(QtCore.QObject):
         new_dock = Dock(self._parent, name, self._parent.qml_engine, widget_id)
         if settings is not None:
             new_dock.restoreState(settings)
-        #self.parent().addDockWidget(QtCore.Qt.TopDockWidgetArea, new_dock)
         self._parent.centralLayout.addWidget(new_dock)
 
         self.docks += [new_dock]
@@ -114,7 +113,6 @@ class DockManager(QtCore.QObject):
             self.logger.info("First launch, display a default set of docks")
             self.docks = [Dock(self.parent(), "Dock %d" % (i), self.parent().qml_engine, widgetId=widget_type) for i, widget_type in enumerate(DEFAULT_DOCKS)]
             for dock in self.docks:
-                #self.parent().addDockWidget(QtCore.Qt.TopDockWidgetArea, dock)
                 self.parent().centralLayout.addWidget(dock)
 
         # Ugh it seems QSettings encodes an empty stack the same as None, and

--- a/friture/generators/BurstSettings.qml
+++ b/friture/generators/BurstSettings.qml
@@ -1,0 +1,24 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import Friture 1.0
+
+Row {
+    id: root
+    required property Burst_Generator_Settings_View_Model viewModel
+    spacing: 8
+
+    SystemPalette { id: systemPalette; colorGroup: SystemPalette.Active }
+
+    Text {
+        text: "Period:"
+        color: systemPalette.text
+        anchors.verticalCenter: parent.verticalCenter
+    }
+    DecimalSpinBox {   
+        binding: root.viewModel.period
+        onDecimalValueModified: root.viewModel.period = decimalValue
+        suffix: " s"
+        decimalFrom: 0.01
+        decimalTo: 60
+    }
+}

--- a/friture/generators/DecimalSpinBox.qml
+++ b/friture/generators/DecimalSpinBox.qml
@@ -1,0 +1,43 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+// a SpinBox that allows decimal values with a suffix
+SpinBox {     
+    property var binding
+    property string suffix: " Hz"
+    property int decimals: 2
+    property real decimalValue: value / decimalFactor
+    property real decimalFrom: 20
+    property real decimalTo: 22000
+    readonly property real decimalFactor: Math.pow(10, decimals)
+
+    signal decimalValueModified()
+
+    id: spinbox
+    from: decimalFrom * decimalFactor
+    value: binding * decimalFactor
+    to: decimalTo * decimalFactor
+    stepSize: decimalFactor
+    editable: true
+
+    onValueModified: spinbox.decimalValueModified()
+
+    validator: DoubleValidator {
+        bottom: Math.min(spinbox.from, spinbox.to)
+        top:  Math.max(spinbox.from, spinbox.to)
+        decimals: spinbox.decimals
+        notation: DoubleValidator.StandardNotation
+    }
+
+    textFromValue: function(value, locale) {
+        return Number(value / decimalFactor).toLocaleString(locale, 'f', spinbox.decimals) + suffix
+    }
+
+    valueFromText: function(text, locale) {
+        if (text.endsWith(suffix)) {
+            text = text.slice(0, -suffix.length).trim();
+        }
+
+        return Number.fromLocaleString(locale, text) * decimalFactor
+    }
+}

--- a/friture/generators/PinkSettings.qml
+++ b/friture/generators/PinkSettings.qml
@@ -1,0 +1,7 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import Friture 1.0
+
+Item {
+    required property Pink_Generator_Settings_View_Model viewModel
+}

--- a/friture/generators/SineSettings.qml
+++ b/friture/generators/SineSettings.qml
@@ -1,0 +1,22 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import Friture 1.0
+
+Row {
+    id: sineSettingsRoot
+    spacing: 8
+    required property Sine_Generator_Settings_View_Model viewModel
+
+    SystemPalette { id: systemPalette; colorGroup: SystemPalette.Active }
+
+    Text {
+        text: "Frequency:"
+        color: systemPalette.text
+        anchors.verticalCenter: parent.verticalCenter
+    }
+
+    DecimalSpinBox {   
+        binding: sineSettingsRoot.viewModel.frequency
+        onDecimalValueModified: sineSettingsRoot.viewModel.frequency = decimalValue
+    }
+}

--- a/friture/generators/SweepSettings.qml
+++ b/friture/generators/SweepSettings.qml
@@ -1,0 +1,59 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import Friture 1.0
+
+Column {
+    id: root
+    required property Sweep_Generator_Settings_View_Model viewModel
+
+    spacing: 8
+
+    SystemPalette { id: systemPalette; colorGroup: SystemPalette.Active }
+
+    Row {
+        spacing: 8
+
+        Text {
+            text: "Start frequency:"
+            color: systemPalette.text
+            anchors.verticalCenter: parent.verticalCenter
+        }
+
+        DecimalSpinBox {   
+            binding: root.viewModel.start_frequency
+            onDecimalValueModified: root.viewModel.start_frequency = decimalValue
+        }
+    }
+
+    Row {
+        spacing: 8
+
+        Text {
+            text: "Stop frequency:"
+            color: systemPalette.text
+            anchors.verticalCenter: parent.verticalCenter
+        }
+
+        DecimalSpinBox {   
+            binding: root.viewModel.stop_frequency
+            onDecimalValueModified: root.viewModel.stop_frequency = decimalValue
+        }
+    }
+
+    Row {
+        spacing: 8
+
+        Text {
+            text: "Period:"
+            color: systemPalette.text
+            anchors.verticalCenter: parent.verticalCenter
+        }
+        DecimalSpinBox {   
+            binding: root.viewModel.period
+            onDecimalValueModified: root.viewModel.period = decimalValue
+            suffix: " s"
+            decimalFrom: 0.01
+            decimalTo: 60
+        }
+    }
+}

--- a/friture/generators/WhiteSettings.qml
+++ b/friture/generators/WhiteSettings.qml
@@ -1,0 +1,7 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import Friture 1.0
+
+Item {
+    required property White_Generator_Settings_View_Model viewModel
+}

--- a/friture/generators/burst.py
+++ b/friture/generators/burst.py
@@ -18,30 +18,26 @@
 # along with Friture.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
-from PyQt5 import QtWidgets
 from friture.audiobackend import SAMPLING_RATE
+from PyQt5.QtCore import QObject, pyqtProperty, pyqtSignal
 
 DEFAULT_BURST_PERIOD_S = 1.
-
 
 class BurstGenerator:
     name = "Burst"
 
     def __init__(self, parent):
-        self.T = 1.
+        self._view_model = Burst_Generator_Settings_View_Model(parent)
 
-        self.settings = SettingsWidget(parent)
-        self.settings.spinBox_burst_period.valueChanged.connect(self.setT)
+    def view_model(self):
+        return self._view_model
 
-    def setT(self, T):
-        self.T = T
-
-    def settingsWidget(self):
-        return self.settings
+    def qml_file_name(self) -> str:
+        return "BurstSettings.qml"
 
     def signal(self, t):
         floatdata = np.zeros(t.shape)
-        i = (t * SAMPLING_RATE) % (self.T * SAMPLING_RATE)
+        i = (t * SAMPLING_RATE) % (self._view_model.period * SAMPLING_RATE)
         n = 1
         ind_plus = np.where(i < n)
         floatdata[ind_plus] = 1.
@@ -52,30 +48,26 @@ class BurstGenerator:
         return floatdata
 
 
-class SettingsWidget(QtWidgets.QWidget):
+class Burst_Generator_Settings_View_Model(QObject):
+    period_changed = pyqtSignal(float)
 
-    def __init__(self, parent):
+    def __init__(self, parent: QObject):
         super().__init__(parent)
+        self._period = DEFAULT_BURST_PERIOD_S
 
-        self.spinBox_burst_period = QtWidgets.QDoubleSpinBox(self)
-        self.spinBox_burst_period.setKeyboardTracking(False)
-        self.spinBox_burst_period.setDecimals(2)
-        self.spinBox_burst_period.setSingleStep(1)
-        self.spinBox_burst_period.setMinimum(0.01)
-        self.spinBox_burst_period.setMaximum(60)
-        self.spinBox_burst_period.setProperty("value", DEFAULT_BURST_PERIOD_S)
-        self.spinBox_burst_period.setObjectName("spinBox_burst_period")
-        self.spinBox_burst_period.setSuffix(" s")
+    @pyqtProperty(float, notify=period_changed)
+    def period(self) -> float:
+        return self._period
 
-        self.formLayout = QtWidgets.QFormLayout(self)
-
-        self.formLayout.addRow("Period:", self.spinBox_burst_period)
-
-        self.setLayout(self.formLayout)
+    @period.setter # type: ignore
+    def period(self, period: float):
+        if self._period != period:
+            self._period = period
+            self.period_changed.emit(period)
 
     def saveState(self, settings):
-        settings.setValue("burst period", self.spinBox_burst_period.value())
+        settings.setValue("burst period", self.period)
 
     def restoreState(self, settings):
         burst_period = settings.value("burst period", DEFAULT_BURST_PERIOD_S, type=float)
-        self.spinBox_burst_period.setValue(burst_period)
+        self.period = burst_period

--- a/friture/generators/pink.py
+++ b/friture/generators/pink.py
@@ -19,10 +19,9 @@
 
 import numpy as np
 from numpy.random import standard_normal
-from PyQt5 import QtWidgets
+from PyQt5.QtCore import QObject
 
 PINK_FIDELITY = 100.
-
 
 def pinknoise(n, rvs=standard_normal):
     if n == 0:
@@ -38,24 +37,25 @@ def pinknoise(n, rvs=standard_normal):
 
     return pink / k
 
-
 class PinkGenerator:
     name = "Pink noise"
 
     def __init__(self, parent):
-        self.settings = SettingsWidget(parent)
+        self._view_model = Pink_Generator_Settings_View_Model(parent)
 
-    def settingsWidget(self):
-        return self.settings
+    def view_model(self):
+        return self._view_model
+
+    def qml_file_name(self) -> str:
+        return "PinkSettings.qml"
 
     def signal(self, t):
         n = len(t)
         return pinknoise(n)
 
+class Pink_Generator_Settings_View_Model(QObject):
 
-class SettingsWidget(QtWidgets.QWidget):
-
-    def __init__(self, parent):
+    def __init__(self, parent: QObject):
         super().__init__(parent)
 
     def saveState(self, settings):

--- a/friture/generators/white.py
+++ b/friture/generators/white.py
@@ -18,26 +18,27 @@
 # along with Friture.  If not, see <http://www.gnu.org/licenses/>.
 
 from numpy.random import standard_normal
-from PyQt5 import QtWidgets
-
+from PyQt5.QtCore import QObject
 
 class WhiteGenerator:
     name = "White noise"
 
     def __init__(self, parent):
-        self.settings = SettingsWidget(parent)
+        self._view_model = White_Generator_Settings_View_Model(parent)
 
-    def settingsWidget(self):
-        return self.settings
+    def view_model(self):
+        return self._view_model
+
+    def qml_file_name(self) -> str:
+        return "WhiteSettings.qml"
 
     def signal(self, t):
         n = len(t)
         return standard_normal(n)
 
+class White_Generator_Settings_View_Model(QObject):
 
-class SettingsWidget(QtWidgets.QWidget):
-
-    def __init__(self, parent):
+    def __init__(self, parent: QObject):
         super().__init__(parent)
 
     def saveState(self, settings):

--- a/friture/longlevels_settings.py
+++ b/friture/longlevels_settings.py
@@ -30,7 +30,7 @@ DEFAULT_RESPONSE_TIME = 20
 
 class LongLevels_Settings_Dialog(QtWidgets.QDialog):
 
-    def __init__(self, parent):
+    def __init__(self, parent, view_model):
         super().__init__(parent)
 
         self.setWindowTitle("Long levels settings")
@@ -77,10 +77,10 @@ class LongLevels_Settings_Dialog(QtWidgets.QDialog):
 
         self.setLayout(self.formLayout)
 
-        self.spinBox_specmin.valueChanged.connect(self.parent().setmin)
-        self.spinBox_specmax.valueChanged.connect(self.parent().setmax)
-        self.spinBox_resptime.valueChanged.connect(self.parent().setresptime)
-        self.spinBox_timemax.valueChanged.connect(self.parent().setduration)
+        self.spinBox_specmin.valueChanged.connect(view_model.setmin)
+        self.spinBox_specmax.valueChanged.connect(view_model.setmax)
+        self.spinBox_resptime.valueChanged.connect(view_model.setresptime)
+        self.spinBox_timemax.valueChanged.connect(view_model.setduration)
 
     # method
     def saveState(self, settings):

--- a/friture/octavespectrum.py
+++ b/friture/octavespectrum.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Friture.  If not, see <http://www.gnu.org/licenses/>.
 
-from PyQt5 import QtWidgets
+from PyQt5.QtCore import QObject
 from numpy import log10, array, arange
 
 from friture.histplot import HistPlot
@@ -38,20 +38,14 @@ from friture.audiobackend import SAMPLING_RATE
 SMOOTH_DISPLAY_TIMER_PERIOD_MS = 25
 
 
-class OctaveSpectrum_Widget(QtWidgets.QWidget):
+class OctaveSpectrum_Widget(QObject):
 
-    def __init__(self, parent, engine):
+    def __init__(self, parent):
         super().__init__(parent)
 
         self.audiobuffer = None
 
-        self.setObjectName("Spectrum_Widget")
-        self.gridLayout = QtWidgets.QGridLayout(self)
-        self.gridLayout.setObjectName("gridLayout")
-        self.gridLayout.setContentsMargins(2, 2, 2, 2)
-        self.PlotZoneSpect = HistPlot(self, engine)
-        self.PlotZoneSpect.setObjectName("PlotZoneSpect")
-        self.gridLayout.addWidget(self.PlotZoneSpect, 0, 0, 1, 1)
+        self.PlotZoneSpect = HistPlot(self)
 
         self.spec_min = DEFAULT_SPEC_MIN
         self.spec_max = DEFAULT_SPEC_MAX
@@ -68,7 +62,13 @@ class OctaveSpectrum_Widget(QtWidgets.QWidget):
         self.setresponsetime(self.response_time)
 
         # initialize the settings dialog
-        self.settings_dialog = OctaveSpectrum_Settings_Dialog(self)
+        self.settings_dialog = OctaveSpectrum_Settings_Dialog(parent, self)
+
+    def qml_file_name(self):
+        return self.PlotZoneSpect.qml_file_name()
+    
+    def view_model(self):
+        return self.PlotZoneSpect.view_model()
 
     # method
     def set_buffer(self, buffer):
@@ -123,9 +123,6 @@ class OctaveSpectrum_Widget(QtWidgets.QWidget):
 
     # method
     def canvasUpdate(self):
-        if not self.isVisible():
-            return
-
         self.PlotZoneSpect.draw()
 
     def setmin(self, value):

--- a/friture/octavespectrum_settings.py
+++ b/friture/octavespectrum_settings.py
@@ -33,8 +33,10 @@ DEFAULT_RESPONSE_TIME_INDEX = 3
 
 class OctaveSpectrum_Settings_Dialog(QtWidgets.QDialog):
 
-    def __init__(self, parent):
+    def __init__(self, parent, view_model):
         super().__init__(parent)
+
+        self.view_model = view_model
 
         self.logger = logging.getLogger(__name__)
 
@@ -93,16 +95,16 @@ class OctaveSpectrum_Settings_Dialog(QtWidgets.QDialog):
         self.setLayout(self.formLayout)
 
         self.comboBox_bandsperoctave.currentIndexChanged.connect(self.bandsperoctavechanged)
-        self.spinBox_specmin.valueChanged.connect(self.parent().setmin)
-        self.spinBox_specmax.valueChanged.connect(self.parent().setmax)
-        self.comboBox_weighting.currentIndexChanged.connect(self.parent().setweighting)
+        self.spinBox_specmin.valueChanged.connect(view_model.setmin)
+        self.spinBox_specmax.valueChanged.connect(view_model.setmax)
+        self.comboBox_weighting.currentIndexChanged.connect(view_model.setweighting)
         self.comboBox_response_time.currentIndexChanged.connect(self.responsetimechanged)
 
     # slot
     def bandsperoctavechanged(self, index):
         bandsperoctave = 3 * 2 ** (index - 1) if index >= 1 else 1
         self.logger.info("bandsperoctavechanged slot %d %d", index, bandsperoctave)
-        self.parent().setbandsperoctave(bandsperoctave)
+        self.view_model.setbandsperoctave(bandsperoctave)
 
     # slot
     def responsetimechanged(self, index):
@@ -117,7 +119,7 @@ class OctaveSpectrum_Settings_Dialog(QtWidgets.QDialog):
         elif index == 4:
             response_time = 5.           
         self.logger.info("responsetimechanged slot %d %d", index, response_time)
-        self.parent().setresponsetime(response_time)
+        self.view_model.setresponsetime(response_time)
 
     # method
     def saveState(self, settings):

--- a/friture/pitch_tracker_settings.py
+++ b/friture/pitch_tracker_settings.py
@@ -31,7 +31,7 @@ DEFAULT_MIN_DB = -70.0
 DEFAULT_FFT_SIZE = 16384
 
 class PitchTrackerSettingsDialog(QtWidgets.QDialog):
-    def __init__(self, parent: QtWidgets.QWidget) -> None:
+    def __init__(self, parent: QtWidgets.QWidget, view_model: Any) -> None:
         super().__init__(parent)
         self.setWindowTitle("Pitch Tracker Settings")
         self.form_layout = QtWidgets.QFormLayout(self)
@@ -43,7 +43,7 @@ class PitchTrackerSettingsDialog(QtWidgets.QDialog):
         self.min_freq.setValue(DEFAULT_MIN_FREQ)
         self.min_freq.setSuffix(" Hz")
         self.min_freq.setObjectName("min_freq")
-        self.min_freq.valueChanged.connect(self.parent().set_min_freq) # type: ignore
+        self.min_freq.valueChanged.connect(view_model.set_min_freq) # type: ignore
         self.form_layout.addRow("Min:", self.min_freq)
 
         self.max_freq = QtWidgets.QSpinBox(self)
@@ -53,7 +53,7 @@ class PitchTrackerSettingsDialog(QtWidgets.QDialog):
         self.max_freq.setValue(DEFAULT_MAX_FREQ)
         self.max_freq.setSuffix(" Hz")
         self.max_freq.setObjectName("max_freq")
-        self.max_freq.valueChanged.connect(self.parent().set_max_freq) # type: ignore
+        self.max_freq.valueChanged.connect(view_model.set_max_freq) # type: ignore
         self.form_layout.addRow("Max:", self.max_freq)
 
         self.duration = QtWidgets.QSpinBox(self)
@@ -63,7 +63,7 @@ class PitchTrackerSettingsDialog(QtWidgets.QDialog):
         self.duration.setValue(DEFAULT_DURATION)
         self.duration.setSuffix(" s")
         self.duration.setObjectName("duration")
-        self.duration.valueChanged.connect(self.parent().set_duration) # type: ignore
+        self.duration.valueChanged.connect(view_model.set_duration) # type: ignore
         self.form_layout.addRow("Duration:", self.duration)
 
         self.min_db = QtWidgets.QDoubleSpinBox(self)
@@ -73,7 +73,7 @@ class PitchTrackerSettingsDialog(QtWidgets.QDialog):
         self.min_db.setValue(DEFAULT_MIN_DB)
         self.min_db.setSuffix(" dB")
         self.min_db.setObjectName("min_db")
-        self.min_db.valueChanged.connect(self.parent().set_min_db) # type: ignore
+        self.min_db.valueChanged.connect(view_model.set_min_db) # type: ignore
         self.form_layout.addRow("Min Amplitude:", self.min_db)
 
         self.setLayout(self.form_layout)

--- a/friture/spectrogram.py
+++ b/friture/spectrogram.py
@@ -19,7 +19,7 @@
 
 """Spectrogram widget, that displays a rolling 2D image of the time-frequency spectrum."""
 
-from PyQt5 import QtWidgets
+from PyQt5.QtCore import QObject
 from numpy import log10, floor, zeros, float64, tile, array, ndarray
 from friture.audiobuffer import AudioBuffer
 from friture.imageplot import ImagePlot
@@ -43,17 +43,12 @@ from friture.audiobackend import SAMPLING_RATE, FRAMES_PER_BUFFER, AudioBackend
 from fractions import Fraction
 
 
-class Spectrogram_Widget(QtWidgets.QWidget):
+class Spectrogram_Widget(QObject):
 
-    def __init__(self, parent, engine):
+    def __init__(self, parent):
         super().__init__(parent)
 
-        self.setObjectName("Spectrogram_Widget")
-        self.gridLayout = QtWidgets.QGridLayout(self)
-        self.gridLayout.setObjectName("gridLayout")
-        self.PlotZoneImage = ImagePlot(self, engine)
-        self.PlotZoneImage.setObjectName("PlotZoneImage")
-        self.gridLayout.addWidget(self.PlotZoneImage, 0, 1, 1, 1)
+        self.PlotZoneImage = ImagePlot(self)
 
         self.audiobuffer = None
 
@@ -106,9 +101,15 @@ class Spectrogram_Widget(QtWidgets.QWidget):
         self.sfft_rate_frac = Fraction(SAMPLING_RATE, self.fft_size) / (Fraction(1) - self.overlap_frac) / 1000
 
         # initialize the settings dialog
-        self.settings_dialog = Spectrogram_Settings_Dialog(self)
+        self.settings_dialog = Spectrogram_Settings_Dialog(parent, self)
 
         self.mustRestart = False
+
+    def qml_file_name(self):
+        return self.PlotZoneImage.qml_file_name()
+
+    def view_model(self):
+        return self.PlotZoneImage.view_model()
 
     # method
     def set_buffer(self, buffer: AudioBuffer) -> None:
@@ -184,9 +185,6 @@ class Spectrogram_Widget(QtWidgets.QWidget):
         # actual displayed spectrogram is a scaled version of the time-frequency plane
 
     def canvasUpdate(self):
-        if not self.isVisible():
-            return
-
         self.PlotZoneImage.draw()
 
     def update_jitter(self):

--- a/friture/spectrogram_settings.py
+++ b/friture/spectrogram_settings.py
@@ -36,10 +36,12 @@ DEFAULT_WEIGHTING = 0  # None
 
 class Spectrogram_Settings_Dialog(QtWidgets.QDialog):
 
-    def __init__(self, parent):
+    def __init__(self, parent, view_model):
         super().__init__(parent)
 
         self.logger = logging.getLogger(__name__)
+
+        self.view_model = view_model
 
         self.setWindowTitle("Spectrogram settings")
 
@@ -126,23 +128,23 @@ class Spectrogram_Settings_Dialog(QtWidgets.QDialog):
 
         self.comboBox_fftsize.currentIndexChanged.connect(self.fftsizechanged)
         self.comboBox_freqscale.currentIndexChanged.connect(self.freqscalechanged)
-        self.spinBox_minfreq.valueChanged.connect(self.parent().setminfreq)
-        self.spinBox_maxfreq.valueChanged.connect(self.parent().setmaxfreq)
-        self.spinBox_specmin.valueChanged.connect(self.parent().setmin)
-        self.spinBox_specmax.valueChanged.connect(self.parent().setmax)
-        self.doubleSpinBox_timerange.valueChanged.connect(self.parent().timerangechanged)
-        self.comboBox_weighting.currentIndexChanged.connect(self.parent().setweighting)
+        self.spinBox_minfreq.valueChanged.connect(view_model.setminfreq)
+        self.spinBox_maxfreq.valueChanged.connect(view_model.setmaxfreq)
+        self.spinBox_specmin.valueChanged.connect(view_model.setmin)
+        self.spinBox_specmax.valueChanged.connect(view_model.setmax)
+        self.doubleSpinBox_timerange.valueChanged.connect(view_model.timerangechanged)
+        self.comboBox_weighting.currentIndexChanged.connect(view_model.setweighting)
 
     # slot
     def fftsizechanged(self, index):
         self.logger.info("fft_size_changed slot %d %d %f", index, 2 ** index * 32, 150000 / 2 ** index * 32)
         fft_size = 2 ** index * 32
-        self.parent().setfftsize(fft_size)
+        self.view_model.setfftsize(fft_size)
 
     # slot
     def freqscalechanged(self, index):
         self.logger.info("freq_scale slot %d %s", index, fscales.ALL[index])
-        self.parent().setfreqscale(fscales.ALL[index])
+        self.view_model.setfreqscale(fscales.ALL[index])
         
     # method
     def saveState(self, settings):

--- a/friture/spectrum.py
+++ b/friture/spectrum.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Friture.  If not, see <http://www.gnu.org/licenses/>.
 
-from PyQt5 import QtWidgets
+from PyQt5.QtCore import QObject
 from numpy import log10, argmax, zeros, arange, floor, float64
 from friture.audioproc import audioproc  # audio processing class
 from friture.spectrum_settings import (Spectrum_Settings_Dialog,  # settings dialog
@@ -37,20 +37,13 @@ from friture.spectrumPlotWidget import SpectrumPlotWidget
 from friture_extensions.exp_smoothing_conv import pyx_exp_smoothed_value_numpy
 
 
-class Spectrum_Widget(QtWidgets.QWidget):
+class Spectrum_Widget(QObject):
 
-    def __init__(self, parent, engine):
+    def __init__(self, parent):
         super().__init__(parent)
 
         self.audiobuffer = None
-
-        self.setObjectName("Spectrum_Widget")
-        self.gridLayout = QtWidgets.QGridLayout(self)
-        self.gridLayout.setObjectName("gridLayout")
-        self.gridLayout.setContentsMargins(2, 2, 2, 2)
-        self.PlotZoneSpect = SpectrumPlotWidget(self, engine)
-        self.PlotZoneSpect.setObjectName("PlotZoneSpect")
-        self.gridLayout.addWidget(self.PlotZoneSpect, 0, 0, 1, 1)
+        self.PlotZoneSpect = SpectrumPlotWidget(self)
 
         # initialize the class instance that will do the fft
         self.proc = audioproc()
@@ -86,7 +79,13 @@ class Spectrum_Widget(QtWidgets.QWidget):
         self.PlotZoneSpect.setShowFreqLabel(DEFAULT_SHOW_FREQ_LABELS)
 
         # initialize the settings dialog
-        self.settings_dialog = Spectrum_Settings_Dialog(self)
+        self.settings_dialog = Spectrum_Settings_Dialog(parent, self)
+
+    def qml_file_name(self):
+        return self.PlotZoneSpect.qml_file_name()
+    
+    def view_model(self):
+        return self.PlotZoneSpect.view_model()
 
     # method
     def set_buffer(self, buffer):

--- a/friture/spectrum_settings.py
+++ b/friture/spectrum_settings.py
@@ -39,8 +39,10 @@ DEFAULT_RESPONSE_TIME_INDEX = 0
 
 class Spectrum_Settings_Dialog(QtWidgets.QDialog):
 
-    def __init__(self, parent):
+    def __init__(self, parent, view_model):
         super().__init__(parent)
+
+        self.view_model = view_model
 
         self.logger = logging.getLogger(__name__)
 
@@ -148,33 +150,33 @@ class Spectrum_Settings_Dialog(QtWidgets.QDialog):
         self.comboBox_dual_channel.currentIndexChanged.connect(self.dualchannelchanged)
         self.comboBox_fftsize.currentIndexChanged.connect(self.fftsizechanged)
         self.comboBox_freqscale.currentIndexChanged.connect(self.freqscalechanged)
-        self.spinBox_minfreq.valueChanged.connect(self.parent().setminfreq)
-        self.spinBox_maxfreq.valueChanged.connect(self.parent().setmaxfreq)
-        self.spinBox_specmin.valueChanged.connect(self.parent().setmin)
-        self.spinBox_specmax.valueChanged.connect(self.parent().setmax)
-        self.comboBox_weighting.currentIndexChanged.connect(self.parent().setweighting)
+        self.spinBox_minfreq.valueChanged.connect(self.view_model.setminfreq)
+        self.spinBox_maxfreq.valueChanged.connect(self.view_model.setmaxfreq)
+        self.spinBox_specmin.valueChanged.connect(self.view_model.setmin)
+        self.spinBox_specmax.valueChanged.connect(self.view_model.setmax)
+        self.comboBox_weighting.currentIndexChanged.connect(self.view_model.setweighting)
         self.comboBox_response_time.currentIndexChanged.connect(self.responsetimechanged)
-        self.checkBox_showFreqLabels.toggled.connect(self.parent().setShowFreqLabel)
-        self.checkBox_showPitchLabel.toggled.connect(self.parent().setShowPitchLabel)
+        self.checkBox_showFreqLabels.toggled.connect(self.view_model.setShowFreqLabel)
+        self.checkBox_showPitchLabel.toggled.connect(self.view_model.setShowPitchLabel)
 
     # slot
     def dualchannelchanged(self, index):
         if index == 0:
-            self.parent().setdualchannels(False)
+            self.view_model.setdualchannels(False)
         else:
-            self.parent().setdualchannels(True)
+            self.view_model.setdualchannels(True)
 
     # slot
     def fftsizechanged(self, index):
         self.logger.info("fft_size_changed slot %d %d %f", index, 2 ** index * 32, 150000 / 2 ** index * 32)
         # FIXME the size should not be found from the index, but attached as item data
         fft_size = 2 ** index * 32
-        self.parent().setfftsize(fft_size)
+        self.view_model.setfftsize(fft_size)
 
     # slot
     def freqscalechanged(self, index):
         self.logger.info("freq_scale slot %d %s", index, fscales.ALL[index].NAME)
-        self.parent().PlotZoneSpect.setfreqscale(fscales.ALL[index])
+        self.view_model.PlotZoneSpect.setfreqscale(fscales.ALL[index])
 
     # slot
     def responsetimechanged(self, index):
@@ -189,7 +191,7 @@ class Spectrum_Settings_Dialog(QtWidgets.QDialog):
         elif index == 4:
             response_time = 5.            
         self.logger.info("responsetimechanged slot %d %d", index, response_time)
-        self.parent().setresponsetime(response_time)
+        self.view_model.setresponsetime(response_time)
 
     # method
     def saveState(self, settings):


### PR DESCRIPTION
All audio widgets are now QML components. This required migrating the delay estimator, the generator, and refactoring the Pitch tracker.

The benefit is that now the creation of the visual part of the audio widget is centralized in dock.py, instead of being copied over in every widget. Also, it promotes a clearer separation between viewmodel and view.

This will allow to continue the conversion of Friture to be a full QML app.

We choose the Fusion style for Qt Quick Controls, used in the Generator view. The Fusion style is appropriate for Desktop apps, and works fine with Dark or White themes as set in the system.

We load the QML using QQuickView, which exposes a setInitialProperties method, unlike QQuickWidget. setInitialProperties allows to pass the viewmodel before the component is initialized, which removes the need for the Loader that was used with QQuickWidget.