### PR TITLE
Environmental changes are now optional

### DIFF
--- a/friture/FritureMainWindow.qml
+++ b/friture/FritureMainWindow.qml
@@ -29,6 +29,7 @@ Rectangle { // eventually move to ApplicationWindow
                     checkable: true
                     checked: mainWindow.main_window_view_model.toolbar_view_model.recording
                     icon.source: startButton.checked ? "qrc:/images-src/stop.svg" : "qrc:/images-src/start.svg"
+                    icon.color: undefined
                     text: startButton.checked ? qsTr("Stop") : qsTr("Start")
                     ToolTip.text: qsTr("Start/Stop")
                     icon.height: 32
@@ -41,6 +42,7 @@ Rectangle { // eventually move to ApplicationWindow
                 ToolButton {
                     id: newDockButton
                     icon.source: "qrc:/images-src/new-dock.svg"
+                    icon.color: undefined
                     text: qsTr("New dock")
                     ToolTip.text: qsTr("Add a new dock to Friture window")
                     icon.height: 32
@@ -52,6 +54,7 @@ Rectangle { // eventually move to ApplicationWindow
                 ToolButton {
                     id: settingsButton
                     icon.source: "qrc:/images-src/tools.svg"
+                    icon.color: undefined
                     text: qsTr("Settings")
                     ToolTip.text: qsTr("Display settings dialog")
                     icon.height: 32
@@ -63,6 +66,7 @@ Rectangle { // eventually move to ApplicationWindow
                 ToolButton {
                     id: aboutButton
                     icon.source: "qrc:/images-src/window-icon.svg"
+                    icon.color: undefined
                     text: qsTr("About Friture")
                     icon.height: 32
                     icon.width: 32

--- a/friture/analyzer.py
+++ b/friture/analyzer.py
@@ -452,7 +452,8 @@ def main():
         logger.info("Applying Windows-specific setup")
 
         # enable automatic scaling for high-DPI screens
-        os.environ["QT_AUTO_SCREEN_SCALE_FACTOR"] = "1"
+        if "QT_AUTO_SCREEN_SCALE_FACTOR" not in os.environ:
+            os.environ["QT_AUTO_SCREEN_SCALE_FACTOR"] = "1"
 
         # set the App ID for Windows 7 to properly display the icon in the
         # taskbar.
@@ -479,7 +480,8 @@ def main():
     # Set the style for Qt Quick Controls
     # We choose the Fusion style as it is a desktop-oriented style
     # It uses the standard system palettes to provide colors that match the desktop environment.
-    os.environ["QT_QUICK_CONTROLS_STYLE"] = "Fusion"
+    if "QT_QUICK_CONTROLS_STYLE" not in os.environ:
+        os.environ["QT_QUICK_CONTROLS_STYLE"] = "Fusion"
 
     # Splash screen
     if not program_arguments.no_splash:


### PR DESCRIPTION
os.envion[] assignments now have a check before them so they are disabled automatically if the system/user has already set a default or an override.

I added `icon.color: undefined` as all themes other than Fusion treat icon sources as a colour mask if this parameter is not set. Please test this to see if it breaks anything on other OSes. Another way of keeping the colours would be to wrap the images in an Image{}.

Running the command `QT_QUICK_CONTROLS_STYLE="Universal" ./main.py` for example changes the style to "Universal"