### PR TITLE
fix(Spectrum): copy data in harmonic product estimation

### DIFF
--- a/friture/spectrum.py
+++ b/friture/spectrum.py
@@ -107,7 +107,7 @@ class Spectrum_Widget(QObject):
   
         # Downsample and multiply
         harmonic_length = sp.shape[0] // product_count
-        res = sp[:harmonic_length]
+        res = sp[:harmonic_length].copy()
         for i in range(2, product_count + 1):
             res *= sp[::i][:harmonic_length]
         return res
@@ -191,7 +191,14 @@ class Spectrum_Widget(QObject):
         self.response_time = response_time
 
         # an exponential smoothing filter is a simple IIR filter
-        # s_i = alpha*x_i + (1-alpha)*s_{i-1}
+        # y_i     = a*x_i     + (1-a)*y_{i-1}
+        #
+        # we can unroll the recurrence a bit:
+        # y_{i+1} = a*x_{i+1} + (1-a)*y_i
+        #         = a*x_{i+1} + (1-a)*a*x_i + (1-a)^2*y_{i-1}
+        # y_{i+2} = a*x_{i+2} + (1-a)*y_{i+1}
+        #         = a*x_{i+2} + (1-a)*a*x_{i+1} + (1-a)^2*a*x_i + (1-a)^3*y_{i-1}
+        # ...
         # we compute alpha so that the N most recent samples represent 100*w percent of the output
         w = 0.65
         delta_n = self.fft_size * (1. - self.overlap)

--- a/friture/spectrum_settings.py
+++ b/friture/spectrum_settings.py
@@ -190,7 +190,7 @@ class Spectrum_Settings_Dialog(QtWidgets.QDialog):
             response_time = 1.
         elif index == 4:
             response_time = 5.            
-        self.logger.info("responsetimechanged slot %d %d", index, response_time)
+        self.logger.info("responsetimechanged slot %d %f", index, response_time)
         self.view_model.setresponsetime(response_time)
 
     # method

--- a/friture_extensions/exp_smoothing_conv.pyx
+++ b/friture_extensions/exp_smoothing_conv.pyx
@@ -15,48 +15,85 @@ def pyx_exp_smoothed_value(np.ndarray[dtype_t, ndim=1] kernel, dtype_t alpha, np
 	cdef Py_ssize_t Nk = kernel.shape[0]
 	cdef Py_ssize_t i
 	cdef dtype_t value, conv
+	cdef double a = (1.-alpha)**N
 	
 	# as we disable the cython bounds checking, do it by ourselves
 	# it is absolutely needed as the kernel is not of infinite size !!
 	if N > Nk:
 		N = Nk
+		a = 0.
 	
 	if N == 0:
 		value = previous
-	else:
-		conv = 0.
-		
-		for i in range(0, N):
-			conv = conv + kernel[Nk - N + i]*data[i]
-		
-		value = alpha * conv + previous*(1.-alpha)**N
+
+	conv = 0.
+	
+	for i in range(0, N):
+		conv = conv + kernel[Nk - N + i]*data[i]
+	
+	value = alpha * conv + previous*a
 	
 	return value
 
+
 def pyx_exp_smoothed_value_numpy(np.ndarray[dtype_t, ndim=1] kernel, dtype_t alpha, np.ndarray[dtype_t, ndim=2] data, np.ndarray[dtype_t, ndim=1] previous):
-	cdef Py_ssize_t N = data.shape[1]
+	"""
+	Compute exponential filtering of data with given kernel and alpha.
+	The filter is applied on the 2nd axis (axis=1), independently for each row (axis=0).
+
+	This is equivalent to applying the following IIR filter on each row of data:
+	y_i = alpha*x_i + (1-alpha)*y_{i-1}
+	where x_i is the input data, y_i the filtered data, and y_{i-1} the previous filtered value.
+
+	We can unroll the recurrence a bit:
+    y_{i+1} = a*x_{i+1} + (1-a)*y_i
+            = a*x_{i+1} + (1-a)*a*x_i + (1-a)^2*y_{i-1}
+    y_{i+2} = a*x_{i+2} + (1-a)*y_{i+1}
+            = a*x_{i+2} + (1-a)*a*x_{i+1} + (1-a)^2*a*x_i + (1-a)^3*y_{i-1}
+    ...
+
+	This unrolling can be implemented with a convolution of a precomputed kernel.         
+	
+	By using a precomputed kernel, this function is optimized to process a large number of samples at once.
+
+	Parameters:
+	-----------
+	kernel : 1D array
+		the pre-computed convolution kernel for the exponential smoothing
+	alpha : float
+		the exponential smoothing factor, between 0 and 1
+	data : 2D array
+		the input data to filter
+	previous : 1D array
+		the previous filtered value
+	Returns:
+	--------
+	1D array
+		the filtered value"""
 	cdef Py_ssize_t Nf = data.shape[0]
+	cdef Py_ssize_t Nt = data.shape[1]
 	cdef Py_ssize_t Nk = kernel.shape[0]
 	cdef Py_ssize_t i, j
 	cdef np.ndarray[dtype_t, ndim=1] value, conv
-	cdef double a = (1.-alpha)**N
+	cdef double a = (1.-alpha)**Nt
 
 	# as we disable the cython bounds checking, do it by ourselves
 	# it is absolutely needed as the kernel is not of infinite size !!
-	if N > Nk:
-		N = Nk
+	if Nt > Nk:
+		Nt = Nk
+		a = 0.
 	
-	if N == 0:
+	if Nt == 0:
 		return previous
-	else:
-		conv = np.zeros(Nf)
-		value = np.zeros(Nf)
-		
-		for i in range(0, N):
-			for j in range(Nf):
-				conv[j] = conv[j] + kernel[Nk - N + i]*data[j, i]
-		
-		for j in range(Nf):
-			value[j] = alpha * conv[j] + previous[j]*a
+
+	conv = np.zeros(Nf, dtype=dtype)
+	value = np.zeros(Nf, dtype=dtype)
 	
-		return value
+	for i in range(0, Nt):
+		for j in range(Nf):
+			conv[j] = conv[j] + kernel[Nk - Nt + i]*data[j, i]
+	
+	for j in range(Nf):
+		value[j] = alpha * conv[j] + previous[j]*a
+
+	return value


### PR DESCRIPTION
The code in `harmonic_product_spectrum` was unexpectedly changing the spectrum array data, because numpy operates on views rather than copies. In turn, this was breaking the low-frequency bins of the FFT spectrum.

Here we fix it by taking a copy of the numpy slice.

The original error is mine, introduced in https://github.com/tlecomte/friture/pull/266.

Fixes #319