### PR TITLE
chore: give links to Github rather than the friture.org address

### DIFF
--- a/friture/about.py
+++ b/friture/about.py
@@ -29,10 +29,11 @@ aboutText = """
 <p> <b>Friture %s</b> (dated %s)</p>
 <p> Friture is an application for real-time audio analysis.</p>
 <p> License is GPLv3.</p>
-<p> Homepage: <a href="http://friture.org">http://friture.org</a></p>
-<p> <a href="http://friture.org/privacy.html">Privacy Policy</a></p>
-<p> Send comments, ideas and bug reports to: <a href="mailto:contact@friture.org">contact@friture.org</a></p>
-<p> Splash screen photo credit: <a href="http://www.flickr.com/photos/visual_dichotomy/3623619145/">visual.dichotomy</a> (CC BY 2.0)</p>
+<p> Homepage: <a href="https://friture.org">https://friture.org</a></p>
+<p> <a href="https://friture.org/privacy.html">Privacy Policy</a></p>
+<p> Submit ideas and bug reports as <a href="https://github.com/tlecomte/friture/issues">Issues</a> on <a href="https://github.com/tlecomte/friture">Friture GitHub project</a>.</p>
+<p> Discuss Friture on <a href="https://github.com/tlecomte/friture/discussions">GitHub Discussions</a>.</p>
+<p> Splash screen photo credit: <a href="https://www.flickr.com/photos/visual_dichotomy/3623619145/">visual.dichotomy</a> (CC BY 2.0)</p>
 <p>This instance of Friture runs thanks to the following external projects:</p>
 
 <ul>

--- a/friture/exceptionhandler.py
+++ b/friture/exceptionhandler.py
@@ -40,20 +40,17 @@ def fileexcepthook(exception_type, exception_value, traceback_object):
     logFileName = "friture.log.txt"
     logDir = platformdirs.user_log_dir("Friture", "")
 
-    email = "contact@friture.org"
-
     notice = """
         <h1>Oops! Something went wrong!</h1>
         <p>Sorry, there was an error we could not handle.</p>
         <p>You can choose to abort, or to ignore the error and try to continue
         (this is not guaranteed to work).</p>
         <h2>Please help us fix it!</h2>\n\n
-        <p>Please contact us directly via email at <a href="mailto:{email}?Subject=Friture%%20acrash report">{email}</a>
+        <p>Please create an issue on <a href="https://github.com/tlecomte/friture/issues">https://github.com/tlecomte/friture/issues</a>
         and include the log file named <i>{logFileName}</i> from the following folder:</p>
         <p><a href="file:///{logDir}">{logDir}1</a></p>
-        <p>Alternatively, if you have a GitHub account, you can create a new issue on <a href="https://github.com/tlecomte/friture/issues">https://github.com/tlecomte/friture/issues</a></p>
         <h3>Error details</h3>""" \
-        .format(email = email, logFileName = logFileName, logDir = logDir)
+        .format(logFileName = logFileName, logDir = logDir)
 
     msg = notice + timeString + ' (%s)' % versionInfo + '<br>' + exceptionText.replace("\r\n", "\n").replace("\n", "<br>").replace(" ", '&nbsp;')
 


### PR DESCRIPTION
This is meant for better communication.