### PR TITLE
Annotate target frequencies

### DIFF
--- a/friture/Plot.qml
+++ b/friture/Plot.qml
@@ -62,10 +62,10 @@ Rectangle {
             Layout.fillHeight: true
             Layout.fillWidth: true
 
+            scopedata: plot.scopedata
+
             vertical_axis: scopedata.vertical_axis
             horizontal_axis: scopedata.horizontal_axis
-
-            annotations: (scopedata.target_frequencies !== undefined) ? scopedata.target_frequencies : []
 
             Item {
                 id: plotItemPlaceholder

--- a/friture/Plot.qml
+++ b/friture/Plot.qml
@@ -65,6 +65,8 @@ Rectangle {
             vertical_axis: scopedata.vertical_axis
             horizontal_axis: scopedata.horizontal_axis
 
+            annotations: (scopedata.target_frequencies !== undefined) ? scopedata.target_frequencies : []
+
             Item {
                 id: plotItemPlaceholder
                 anchors.fill: parent

--- a/friture/PlotArea.qml
+++ b/friture/PlotArea.qml
@@ -11,6 +11,8 @@ Item {
     required property Axis vertical_axis
     required property Axis horizontal_axis
 
+    property var annotations: []
+
     default property alias content: plotItemPlaceholder.children
 
     PlotBackground {
@@ -29,6 +31,23 @@ Item {
     Item {
         id: plotItemPlaceholder
         anchors.fill: parent
+    }
+
+    Repeater {
+        id: annotationRepeater
+        anchors.fill: parent
+
+        model: scopePlotArea.annotations
+
+        Rectangle {
+            width: parent.width
+            height: 1
+            color: "red"
+            y: (1.0 - scopePlotArea.vertical_axis.coordinate_transform.toScreen(modelData)) * parent.height
+
+            visible: modelData >= scopePlotArea.vertical_axis.min && modelData <= scopePlotArea.vertical_axis.max
+        }
+
     }
 
     Rectangle {

--- a/friture/PlotArea.qml
+++ b/friture/PlotArea.qml
@@ -40,12 +40,11 @@ Item {
         model: scopePlotArea.annotations
 
         Rectangle {
+            x: 0
+            y: parent.height * (1. - scopePlotArea.vertical_axis.coordinate_transform.toScreen(modelData) )
             width: parent.width
             height: 1
-            color: "red"
-            y: (1.0 - scopePlotArea.vertical_axis.coordinate_transform.toScreen(modelData)) * parent.height
-
-            visible: modelData >= scopePlotArea.vertical_axis.min && modelData <= scopePlotArea.vertical_axis.max
+            color: "magenta"
         }
 
     }

--- a/friture/PlotArea.qml
+++ b/friture/PlotArea.qml
@@ -8,10 +8,9 @@ Item {
 
     SystemPalette { id: systemPalette; colorGroup: SystemPalette.Active }
 
+    required property var scopedata
     required property Axis vertical_axis
     required property Axis horizontal_axis
-
-    property var annotations: []
 
     default property alias content: plotItemPlaceholder.children
 
@@ -37,14 +36,14 @@ Item {
         id: annotationRepeater
         anchors.fill: parent
 
-        model: scopePlotArea.annotations
+        model: scopePlotArea.scopedata.target_frequencies
 
         Rectangle {
             x: 0
             y: parent.height * (1. - scopePlotArea.vertical_axis.coordinate_transform.toScreen(modelData) )
             width: parent.width
             height: 1
-            color: "magenta"
+            color: "lime"
         }
 
     }
@@ -105,5 +104,19 @@ Item {
         id: plotMouseArea
         anchors.fill: parent
         cursorShape: Qt.CrossCursor
+        acceptedButtons: Qt.LeftButton | Qt.RightButton
+
+        onClicked: {
+            if (mouse.button !== Qt.RightButton) { return; }
+            var freq = vertical_axis.coordinate_transform.toPlot((parent.height - mouse.y) / parent.height);
+            for (var existingFreq of scopedata.target_frequencies) {
+                var existingCoord = parent.height * (1 - scopePlotArea.vertical_axis.coordinate_transform.toScreen(existingFreq));
+                if (Math.abs(existingCoord - mouse.y) < 5) {
+                    scopedata.remove_target_frequency(existingFreq);
+                    return;
+                }
+            }
+            scopedata.add_target_frequency(freq);
+        }
     }
 }

--- a/friture/spectrogram_data.py
+++ b/friture/spectrogram_data.py
@@ -17,9 +17,25 @@
 # You should have received a copy of the GNU General Public License
 # along with Friture.  If not, see <http://www.gnu.org/licenses/>.
 
+from PyQt5 import QtCore
+from PyQt5.QtCore import pyqtProperty
+
 from friture.scope_data import Scope_Data
 
 class Spectrogram_Data(Scope_Data):
+    target_frequencies_changed = QtCore.pyqtSignal()
 
     def __init__(self, parent=None):
         super().__init__(parent)
+        self._target_frequencies = [100., 165., 185.]
+
+
+    @pyqtProperty('QVariantList', notify=target_frequencies_changed) # type: ignore
+    def target_frequencies(self):
+        return self._target_frequencies
+
+    @target_frequencies.setter
+    def target_frequencies(self, freqs):
+        if self._target_frequencies != freqs:
+            self._target_frequencies = freqs
+            self.target_frequencies_changed.emit()

--- a/friture/spectrogram_data.py
+++ b/friture/spectrogram_data.py
@@ -18,7 +18,7 @@
 # along with Friture.  If not, see <http://www.gnu.org/licenses/>.
 
 from PyQt5 import QtCore
-from PyQt5.QtCore import pyqtProperty
+from PyQt5.QtCore import pyqtProperty, pyqtSlot
 
 from friture.scope_data import Scope_Data
 
@@ -27,7 +27,7 @@ class Spectrogram_Data(Scope_Data):
 
     def __init__(self, parent=None):
         super().__init__(parent)
-        self._target_frequencies = [100., 165., 185.]
+        self._target_frequencies = []
 
 
     @pyqtProperty('QVariantList', notify=target_frequencies_changed) # type: ignore
@@ -39,3 +39,13 @@ class Spectrogram_Data(Scope_Data):
         if self._target_frequencies != freqs:
             self._target_frequencies = freqs
             self.target_frequencies_changed.emit()
+
+    @pyqtSlot(float)
+    def add_target_frequency(self, frequency):
+        if frequency not in self._target_frequencies:
+            self._target_frequencies.append(frequency)
+            self.target_frequencies_changed.emit()
+
+    @pyqtSlot(float)
+    def remove_target_frequency(self, frequency):
+        self.target_frequencies = [f for f in self._target_frequencies if f != frequency]


### PR DESCRIPTION
Hello!

Something I've wanted & heard from other people, but had to work around, is the ability to annotate target frequencies in the spectrogram view. I've implemented that here, trying to keep the changes as minimal as possible. Right now, the lines are hard-coded green, toggle-able by right-clicking, and do not persist. If this change is amenable for merging, I'd be happy to improve those deficiencies.

A screenshot showing three targets added:

<img width="1421" height="1026" alt="Screenshot 2026-01-27 at 12 01 44" src="https://github.com/user-attachments/assets/fb953e8e-0e96-48ac-b247-2e46cc6772be" />
