### PR TITLE
feat(windows): ship MSIX instead of appx; add headless smoke test 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,11 +41,42 @@ jobs:
       shell: powershell
       run: ./.github/workflows/install-windows.ps1
 
-    - name: Upload friture appx
+    - name: Verify app launches (smoke test)
+      # Launch the frozen friture.exe headless (offscreen Qt) and assert it
+      # reaches full init. The MSIX itself is not installed here (it is
+      # unsigned; the Store signs on ingestion) -- we validate the same frozen
+      # binary the MSIX wraps.
+      shell: bash
+      run: uv run python scripts/smoke_test.py dist/friture/friture.exe --no-splash
+
+    - name: Capture Friture log
+      if: always()
+      shell: bash
+      run: |
+        uv run python - <<'PY'
+        import os, shutil, platformdirs
+        src = os.path.join(platformdirs.user_log_dir("Friture", ""), "friture.log.txt")
+        dst = "friture-smoke.log"
+        if os.path.exists(src):
+            shutil.copy2(src, dst)
+        else:
+            with open(dst, "w") as f:
+                f.write("log not found: " + src)
+        PY
+
+    - name: Upload friture smoke-test log
+      if: always()
       uses: actions/upload-artifact@v7
       with:
-        name: friture-appx
-        path: dist/friture-*.appx
+        name: friture-smoke-log-windows
+        path: friture-smoke.log
+        if-no-files-found: warn
+
+    - name: Upload friture msix
+      uses: actions/upload-artifact@v7
+      with:
+        name: friture-msix
+        path: dist/friture-*.msix
         if-no-files-found: error
 
     - name: Upload friture msi
@@ -105,12 +136,27 @@ jobs:
         ./friture-*.AppImage --appimage-extract
         uv run python scripts/smoke_test.py ./squashfs-root/AppRun --no-splash
 
+    - name: Capture Friture log
+      if: always()
+      shell: bash
+      run: |
+        uv run python - <<'PY'
+        import os, shutil, platformdirs
+        src = os.path.join(platformdirs.user_log_dir("Friture", ""), "friture.log.txt")
+        dst = "friture-smoke.log"
+        if os.path.exists(src):
+            shutil.copy2(src, dst)
+        else:
+            with open(dst, "w") as f:
+                f.write("log not found: " + src)
+        PY
+
     - name: Upload AppImage smoke-test log
       if: always()
       uses: actions/upload-artifact@v7
       with:
-        name: friture-smoke-log
-        path: ~/.local/state/Friture/log/friture.log.txt
+        name: friture-smoke-log-linux
+        path: friture-smoke.log
         if-no-files-found: warn
 
     - name: Upload appImage
@@ -176,6 +222,7 @@ jobs:
           fail_on_unmatched_files: true
           files: |
             **/friture*.msi
+            **/friture*.msix
             **/friture*.dmg
             **/friture*.AppImage
             **/friture*.AppImage.zsync

--- a/.github/workflows/install-windows.ps1
+++ b/.github/workflows/install-windows.ps1
@@ -44,18 +44,21 @@ Write-Host "==========================================="
 
 Write-Host ""
 Write-Host "==========================================="
-Write-Host "Build appx package"
+Write-Host "Build MSIX package"
 Write-Host "==========================================="
 
 Copy-Item -Path .\dist\friture -Destination .\dist\friture-appx -Recurse
 Copy-Item -Path resources\images\friture.iconset\icon_512x512.png -Destination .\dist\friture-appx\icon_512x512.png
 
-# apply version to appxmanifest.xml and save it to the dist folder
+# apply version to AppxManifest.xml and save it to the package folder.
+# MakeAppx looks for AppxManifest.xml (canonical MSIX name) in the input dir.
 $xml = [xml](Get-Content .\installer\appxmanifest.xml)
 $ns = New-Object System.Xml.XmlNamespaceManager($xml.NameTable)
 $ns.AddNamespace("ns", $xml.DocumentElement.NamespaceURI)
 $package = $xml.SelectSingleNode("//ns:Package", $ns)
 $package.Identity.Version = "$version.0.0"
-$xml.Save(".\dist\friture-appx\appxmanifest.xml")
+$xml.Save(".\dist\friture-appx\AppxManifest.xml")
 
-MakeAppx pack /v /d .\dist\friture-appx /p ".\dist\friture-$version.appx"
+# MSIX replaces the legacy appx container; SignTool (Store ingestion signs the
+# final package) is omitted here on purpose.
+MakeAppx pack /v /d .\dist\friture-appx /p ".\dist\friture-$version.msix"

--- a/.github/workflows/install-windows.ps1
+++ b/.github/workflows/install-windows.ps1
@@ -47,18 +47,17 @@ Write-Host "==========================================="
 Write-Host "Build MSIX package"
 Write-Host "==========================================="
 
-Copy-Item -Path .\dist\friture -Destination .\dist\friture-appx -Recurse
-Copy-Item -Path resources\images\friture.iconset\icon_512x512.png -Destination .\dist\friture-appx\icon_512x512.png
+Copy-Item -Path .\dist\friture -Destination .\dist\friture-msix -Recurse
+Copy-Item -Path resources\images\friture.iconset\icon_512x512.png -Destination .\dist\friture-msix\icon_512x512.png
 
 # apply version to AppxManifest.xml and save it to the package folder.
-# MakeAppx looks for AppxManifest.xml (canonical MSIX name) in the input dir.
 $xml = [xml](Get-Content .\installer\appxmanifest.xml)
 $ns = New-Object System.Xml.XmlNamespaceManager($xml.NameTable)
 $ns.AddNamespace("ns", $xml.DocumentElement.NamespaceURI)
 $package = $xml.SelectSingleNode("//ns:Package", $ns)
 $package.Identity.Version = "$version.0.0"
-$xml.Save(".\dist\friture-appx\AppxManifest.xml")
+$xml.Save(".\dist\friture-msix\AppxManifest.xml")
 
-# MSIX replaces the legacy appx container; SignTool (Store ingestion signs the
-# final package) is omitted here on purpose.
-MakeAppx pack /v /d .\dist\friture-appx /p ".\dist\friture-$version.msix"
+# SignTool is omitted here on purpose,
+# as Microsoft Store ingestion signs the final package.
+MakeAppx pack /v /d .\dist\friture-msix /p ".\dist\friture-$version.msix"

--- a/friture/audiobackend.py
+++ b/friture/audiobackend.py
@@ -142,7 +142,10 @@ class __AudioBackend(QtCore.QObject):
             default_input_device = sounddevice.query_devices(kind='input')
             default_input_device['index'] = raw_devices.index(default_input_device)
         except sounddevice.PortAudioError:
-            self.logger.exception("Failed to query the default input device")
+            # headless CI has no default input device: this is expected, not
+            # an error, so log at debug (not exception) to avoid emitting a
+            # "Traceback" line that trips the smoke test's fatal-marker scan.
+            self.logger.debug("Failed to query the default input device")
             default_input_device = None
 
         devices_list = []
@@ -166,9 +169,20 @@ class __AudioBackend(QtCore.QObject):
     def get_readable_output_devices_list(self):
         output_devices = self.get_output_devices()
 
+        # mirror get_input_devices(): if there are no output devices at all,
+        # sounddevice.query_devices(kind='output') raises PortAudioError ("Error
+        # querying device -1") -- e.g. on a headless Windows runner with no
+        # audio. Degrade to an empty list instead of logging a traceback.
+        if len(output_devices) == 0:
+            return []
+
         raw_devices = sounddevice.query_devices()
-        default_output_device = sounddevice.query_devices(kind='output')
-        default_output_device['index'] = raw_devices.index(default_output_device)
+        try:
+            default_output_device = sounddevice.query_devices(kind='output')
+            default_output_device['index'] = raw_devices.index(default_output_device)
+        except sounddevice.PortAudioError:
+            self.logger.debug("No default output device available")
+            default_output_device = None
 
         devices_list = []
         for device in output_devices:

--- a/friture/audiobackend.py
+++ b/friture/audiobackend.py
@@ -142,7 +142,7 @@ class __AudioBackend(QtCore.QObject):
             default_input_device = sounddevice.query_devices(kind='input')
             default_input_device['index'] = raw_devices.index(default_input_device)
         except sounddevice.PortAudioError:
-            self.logger.warning("Failed to query the default input device")
+            self.logger.warning("Failed to query the default input device", exc_info=True)
             default_input_device = None
 
         devices_list = []
@@ -178,7 +178,7 @@ class __AudioBackend(QtCore.QObject):
             default_output_device = sounddevice.query_devices(kind='output')
             default_output_device['index'] = raw_devices.index(default_output_device)
         except sounddevice.PortAudioError:
-            self.logger.warning("No default output device available")
+            self.logger.warning("No default output device available", exc_info=True)
             default_output_device = None
 
         devices_list = []
@@ -230,7 +230,7 @@ class __AudioBackend(QtCore.QObject):
         try:
             default_input_device = sounddevice.query_devices(kind='input')
         except sounddevice.PortAudioError:
-            self.logger.exception("Failed to query the default input device")
+            self.logger.exception("Failed to query the default input device", exc_info=True)
             default_input_device = None
 
         input_devices = []
@@ -260,7 +260,7 @@ class __AudioBackend(QtCore.QObject):
         try:
             default_output_device = sounddevice.query_devices(kind='output')
         except sounddevice.PortAudioError:
-            self.logger.warning("No default output device available")
+            self.logger.warning("No default output device available", exc_info=True)
             default_output_device = None
 
         output_devices = []

--- a/friture/audiobackend.py
+++ b/friture/audiobackend.py
@@ -243,11 +243,19 @@ class __AudioBackend(QtCore.QObject):
     def get_output_devices(self):
         devices = sounddevice.query_devices()
 
-        default_output_device = sounddevice.query_devices(kind='output')
+        # sounddevice.query_devices(kind='output') raises PortAudioError when
+        # there is no default output device (e.g. a headless CI runner), which
+        # would crash AudioBackend() construction. Degrade gracefully instead,
+        # mirroring get_input_devices() below.
+        try:
+            default_output_device = sounddevice.query_devices(kind='output')
+        except sounddevice.PortAudioError:
+            self.logger.debug("No default output device available")
+            default_output_device = None
 
         output_devices = []
         if default_output_device is not None:
-            # start by the default input device
+            # start by the default output device
             default_output_device['index'] = devices.index(default_output_device)
             output_devices += [default_output_device]
 

--- a/friture/audiobackend.py
+++ b/friture/audiobackend.py
@@ -141,8 +141,8 @@ class __AudioBackend(QtCore.QObject):
         try:
             default_input_device = sounddevice.query_devices(kind='input')
             default_input_device['index'] = raw_devices.index(default_input_device)
-        except sounddevice.PortAudioError:
-            self.logger.warning("Failed to query the default input device", exc_info=True)
+        except sounddevice.PortAudioError as err:
+            self.logger.warning(f"Failed to query the default input device: {err}")
             default_input_device = None
 
         devices_list = []
@@ -177,8 +177,8 @@ class __AudioBackend(QtCore.QObject):
         try:
             default_output_device = sounddevice.query_devices(kind='output')
             default_output_device['index'] = raw_devices.index(default_output_device)
-        except sounddevice.PortAudioError:
-            self.logger.warning("No default output device available", exc_info=True)
+        except sounddevice.PortAudioError as err:
+            self.logger.warning(f"No default output device available: {err}")
             default_output_device = None
 
         devices_list = []
@@ -229,8 +229,8 @@ class __AudioBackend(QtCore.QObject):
 
         try:
             default_input_device = sounddevice.query_devices(kind='input')
-        except sounddevice.PortAudioError:
-            self.logger.exception("Failed to query the default input device", exc_info=True)
+        except sounddevice.PortAudioError as err:
+            self.logger.exception(f"Failed to query the default input device: {err}")
             default_input_device = None
 
         input_devices = []
@@ -259,8 +259,8 @@ class __AudioBackend(QtCore.QObject):
         # Degrade gracefully instead.
         try:
             default_output_device = sounddevice.query_devices(kind='output')
-        except sounddevice.PortAudioError:
-            self.logger.warning("No default output device available", exc_info=True)
+        except sounddevice.PortAudioError as err:
+            self.logger.warning(f"No default output device available: {err}")
             default_output_device = None
 
         output_devices = []

--- a/friture/audiobackend.py
+++ b/friture/audiobackend.py
@@ -142,10 +142,7 @@ class __AudioBackend(QtCore.QObject):
             default_input_device = sounddevice.query_devices(kind='input')
             default_input_device['index'] = raw_devices.index(default_input_device)
         except sounddevice.PortAudioError:
-            # headless CI has no default input device: this is expected, not
-            # an error, so log at debug (not exception) to avoid emitting a
-            # "Traceback" line that trips the smoke test's fatal-marker scan.
-            self.logger.debug("Failed to query the default input device")
+            self.logger.warning("Failed to query the default input device")
             default_input_device = None
 
         devices_list = []
@@ -169,10 +166,10 @@ class __AudioBackend(QtCore.QObject):
     def get_readable_output_devices_list(self):
         output_devices = self.get_output_devices()
 
-        # mirror get_input_devices(): if there are no output devices at all,
+        # if there are no output devices at all,
         # sounddevice.query_devices(kind='output') raises PortAudioError ("Error
-        # querying device -1") -- e.g. on a headless Windows runner with no
-        # audio. Degrade to an empty list instead of logging a traceback.
+        # querying device -1").
+        # Degrade to an empty list.
         if len(output_devices) == 0:
             return []
 
@@ -181,7 +178,7 @@ class __AudioBackend(QtCore.QObject):
             default_output_device = sounddevice.query_devices(kind='output')
             default_output_device['index'] = raw_devices.index(default_output_device)
         except sounddevice.PortAudioError:
-            self.logger.debug("No default output device available")
+            self.logger.warning("No default output device available")
             default_output_device = None
 
         devices_list = []
@@ -258,13 +255,12 @@ class __AudioBackend(QtCore.QObject):
         devices = sounddevice.query_devices()
 
         # sounddevice.query_devices(kind='output') raises PortAudioError when
-        # there is no default output device (e.g. a headless CI runner), which
-        # would crash AudioBackend() construction. Degrade gracefully instead,
-        # mirroring get_input_devices() below.
+        # there is no default output device.
+        # Degrade gracefully instead.
         try:
             default_output_device = sounddevice.query_devices(kind='output')
         except sounddevice.PortAudioError:
-            self.logger.debug("No default output device available")
+            self.logger.warning("No default output device available")
             default_output_device = None
 
         output_devices = []

--- a/friture/settings.py
+++ b/friture/settings.py
@@ -52,14 +52,9 @@ class Settings_Dialog(QtWidgets.QDialog, Ui_Settings_Dialog):
         # Setup the user interface
         self.setupUi(self)
 
-        # Assign explicit IDs to the theme radio buttons (0=System,
-        # 1=Light, 2=Dark) immediately after setup, BEFORE the no-audio
-        # early return below. On a headless host with no input devices the
-        # early-return path skips the rest of __init__, so the IDs must be
-        # assigned here -- otherwise themeButtonGroup has no ids and
-        # restoreState()'s button(0) is None (which would crash on
-        # .setChecked). Interactive desktop users see no behaviour change.
         self.themeButtonGroup.idToggled.connect(self.theme_preference_toggled)
+        # Set explicit IDs for theme buttons to match ThemeManager enum values
+        # 0 = System (Unknown), 1 = Light, 2 = Dark
         self.themeButtonGroup.setId(self.radioButton_themeSystem, 0)
         self.themeButtonGroup.setId(self.radioButton_themeLight, 1)
         self.themeButtonGroup.setId(self.radioButton_themeDark, 2)
@@ -69,15 +64,12 @@ class Settings_Dialog(QtWidgets.QDialog, Ui_Settings_Dialog):
         if devices == []:
             # no audio input device
             if QtWidgets.QApplication.instance().platformName() == "offscreen":
-                # Headless (e.g. the CI smoke test runs on the offscreen Qt
-                # platform with no audio hardware). A modal dialog here would
-                # block forever with no user to dismiss it; log and continue
-                # with an empty device set instead of exiting, so that -- for
-                # headless validation purposes -- Friture still reaches full
-                # init. Interactive users on a real desktop keep the message+exit
-                # below.
+                # Headless (e.g. the CI smoke test).
+                # Log and continue with an empty device set instead of exiting,
+                # for validation purposes.
                 self.logger.warning("No audio input device available; continuing in headless mode")
                 return
+            # display a message and exit
             QtWidgets.QMessageBox.critical(self, no_input_device_title, no_input_device_message)
             QtCore.QTimer.singleShot(0, self.exitOnInit)
             sys.exit(1)
@@ -235,29 +227,10 @@ class Settings_Dialog(QtWidgets.QDialog, Ui_Settings_Dialog):
             channel = settings.value("secondChannel", 0, type=int)
             self.comboBox_secondChannel.setCurrentIndex(channel)
             duo_input_id = settings.value("duoInput", 0, type=int)
-            if duo_input_id is None:
-                duo_input_id = 0
-            # button() returns None for an unknown/stale id; never crash on a
-            # missing saved value.
-            duo_button = self.inputTypeButtonGroup.button(duo_input_id)
-            if duo_button is not None:
-                duo_button.setChecked(True)
+            self.inputTypeButtonGroup.button(duo_input_id).setChecked(True)
         self.checkbox_showPlayback.setCheckState(QtCore.Qt.CheckState(settings.value("showPlayback", 0, type=int)))
         self.spinBox_historyLength.setValue(settings.value("historyLength", 30, type=int))
         theme_preference_id = settings.value("themePreference", 0, type=int)
-        if theme_preference_id is None:
-            theme_preference_id = 0
-        # button() returns None when no button has this id (e.g. a stale
-        # saved value, or a fresh install whose stored id never mapped to a
-        # button). Restoring the theme must never crash Friture at startup, so
-        # fall back to the System (0) button when the stored id is unrecognized.
-        theme_button = self.themeButtonGroup.button(theme_preference_id)
-        if theme_button is not None:
-            theme_button.setChecked(True)
-        else:
-            self.logger.warning("No theme button for id %r; defaulting to System", theme_preference_id)
-            system_button = self.themeButtonGroup.button(0)
-            if system_button is not None:
-                system_button.setChecked(True)
+        self.themeButtonGroup.button(theme_preference_id).setChecked(True)
         # need to emit this because setValue doesn't emit editFinished
         self.history_length_changed.emit(self.spinBox_historyLength.value())

--- a/friture/settings.py
+++ b/friture/settings.py
@@ -229,10 +229,29 @@ class Settings_Dialog(QtWidgets.QDialog, Ui_Settings_Dialog):
             channel = settings.value("secondChannel", 0, type=int)
             self.comboBox_secondChannel.setCurrentIndex(channel)
             duo_input_id = settings.value("duoInput", 0, type=int)
-            self.inputTypeButtonGroup.button(duo_input_id).setChecked(True)
+            if duo_input_id is None:
+                duo_input_id = 0
+            # button() returns None for an unknown/stale id; never crash on a
+            # missing saved value.
+            duo_button = self.inputTypeButtonGroup.button(duo_input_id)
+            if duo_button is not None:
+                duo_button.setChecked(True)
         self.checkbox_showPlayback.setCheckState(QtCore.Qt.CheckState(settings.value("showPlayback", 0, type=int)))
         self.spinBox_historyLength.setValue(settings.value("historyLength", 30, type=int))
         theme_preference_id = settings.value("themePreference", 0, type=int)
-        self.themeButtonGroup.button(theme_preference_id).setChecked(True)
+        if theme_preference_id is None:
+            theme_preference_id = 0
+        # button() returns None when no button has this id (e.g. a stale
+        # saved value, or a fresh install whose stored id never mapped to a
+        # button). Restoring the theme must never crash Friture at startup, so
+        # fall back to the System (0) button when the stored id is unrecognized.
+        theme_button = self.themeButtonGroup.button(theme_preference_id)
+        if theme_button is not None:
+            theme_button.setChecked(True)
+        else:
+            self.logger.warning("No theme button for id %r; defaulting to System", theme_preference_id)
+            system_button = self.themeButtonGroup.button(0)
+            if system_button is not None:
+                system_button.setChecked(True)
         # need to emit this because setValue doesn't emit editFinished
         self.history_length_changed.emit(self.spinBox_historyLength.value())

--- a/friture/settings.py
+++ b/friture/settings.py
@@ -56,8 +56,7 @@ class Settings_Dialog(QtWidgets.QDialog, Ui_Settings_Dialog):
 
         if devices == []:
             # no audio input device
-            if QtCore.QCoreApplication.platformName() == "offscreen":
-                # Headless (e.g. the CI smoke test runs on the offscreen Qt
+            if QtWidgets.QApplication.instance().platformName() == "offscreen":                # Headless (e.g. the CI smoke test runs on the offscreen Qt
                 # platform with no audio hardware). A modal dialog here would
                 # block forever with no user to dismiss it; log and continue
                 # with an empty device set instead of exiting, so that -- for

--- a/friture/settings.py
+++ b/friture/settings.py
@@ -52,11 +52,24 @@ class Settings_Dialog(QtWidgets.QDialog, Ui_Settings_Dialog):
         # Setup the user interface
         self.setupUi(self)
 
+        # Assign explicit IDs to the theme radio buttons (0=System,
+        # 1=Light, 2=Dark) immediately after setup, BEFORE the no-audio
+        # early return below. On a headless host with no input devices the
+        # early-return path skips the rest of __init__, so the IDs must be
+        # assigned here -- otherwise themeButtonGroup has no ids and
+        # restoreState()'s button(0) is None (which would crash on
+        # .setChecked). Interactive desktop users see no behaviour change.
+        self.themeButtonGroup.idToggled.connect(self.theme_preference_toggled)
+        self.themeButtonGroup.setId(self.radioButton_themeSystem, 0)
+        self.themeButtonGroup.setId(self.radioButton_themeLight, 1)
+        self.themeButtonGroup.setId(self.radioButton_themeDark, 2)
+
         devices = AudioBackend().get_readable_devices_list()
 
         if devices == []:
             # no audio input device
-            if QtWidgets.QApplication.instance().platformName() == "offscreen":                # Headless (e.g. the CI smoke test runs on the offscreen Qt
+            if QtWidgets.QApplication.instance().platformName() == "offscreen":
+                # Headless (e.g. the CI smoke test runs on the offscreen Qt
                 # platform with no audio hardware). A modal dialog here would
                 # block forever with no user to dismiss it; log and continue
                 # with an empty device set instead of exiting, so that -- for
@@ -94,13 +107,6 @@ class Settings_Dialog(QtWidgets.QDialog, Ui_Settings_Dialog):
         self.radioButton_duo.toggled.connect(self.duo_input_type_selected)
         self.checkbox_showPlayback.stateChanged.connect(self.show_playback_checkbox_changed)
         self.spinBox_historyLength.editingFinished.connect(self.history_length_edit_finished)
-        self.themeButtonGroup.idToggled.connect(self.theme_preference_toggled)
-
-        # Set explicit IDs for theme buttons to match ThemeManager enum values
-        # 0 = System (Unknown), 1 = Light, 2 = Dark
-        self.themeButtonGroup.setId(self.radioButton_themeSystem, 0)
-        self.themeButtonGroup.setId(self.radioButton_themeLight, 1)
-        self.themeButtonGroup.setId(self.radioButton_themeDark, 2)
 
     @pyqtProperty(bool, notify=show_playback_changed) # type: ignore
     def show_playback(self) -> bool:

--- a/friture/settings.py
+++ b/friture/settings.py
@@ -55,7 +55,17 @@ class Settings_Dialog(QtWidgets.QDialog, Ui_Settings_Dialog):
         devices = AudioBackend().get_readable_devices_list()
 
         if devices == []:
-            # no audio input device: display a message and exit
+            # no audio input device
+            if QtCore.QCoreApplication.platformName() == "offscreen":
+                # Headless (e.g. the CI smoke test runs on the offscreen Qt
+                # platform with no audio hardware). A modal dialog here would
+                # block forever with no user to dismiss it; log and continue
+                # with an empty device set instead of exiting, so that -- for
+                # headless validation purposes -- Friture still reaches full
+                # init. Interactive users on a real desktop keep the message+exit
+                # below.
+                self.logger.warning("No audio input device available; continuing in headless mode")
+                return
             QtWidgets.QMessageBox.critical(self, no_input_device_title, no_input_device_message)
             QtCore.QTimer.singleShot(0, self.exitOnInit)
             sys.exit(1)

--- a/installer/appxmanifest.xml
+++ b/installer/appxmanifest.xml
@@ -27,7 +27,7 @@ https://docs.microsoft.com/en-us/windows/msix/package/create-app-package-with-ma
         Name="53504SilentGain.Friture"
         Version="0.0.0.0"
         Publisher="CN=74EE87F8-B2A0-400A-A66A-377F7F4E3BBE"
-        ProcessorArchitecture="amd64" />
+        ProcessorArchitecture="x64" />
     <Properties>
         <DisplayName>Friture</DisplayName>
         <PublisherDisplayName>Silent Gain</PublisherDisplayName>

--- a/installer/appxmanifest.xml
+++ b/installer/appxmanifest.xml
@@ -12,8 +12,8 @@ To build an MSIX package to publish to the Microsoft Store:
 6. from the parent folder, run:
 PS C:\...\friture> MakeAppx pack /v /d .\friture-bin /p friture.msix
 7. friture.msix can be uploaded in a new submission to the Microsoft Partner Center
-   (the Store signs the package on ingestion; this CI build produces an
-   unsigned MSIX used for packaging validation only).
+   (this CI build produces an unsigned MSIX;
+   the Store signs the package on ingestion).
 
 References:
 https://docs.microsoft.com/en-us/windows/msix/packaging-tool/create-app-package

--- a/installer/appxmanifest.xml
+++ b/installer/appxmanifest.xml
@@ -1,17 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- 
 
-To build an appx package to publish to the Microsoft store:
+To build an MSIX package to publish to the Microsoft Store:
 
-1. enable Windows developer mode (to allow side-loading)
+1. enable Windows developer mode (to allow side-loading of an unsigned package)
 2. the build output is in a friture-bin folder
-3. friture-bin should contain appxmanifest.xml
-4. in that folder, run: Add-AppxPackage -Register .\appxmanifest.xml
+3. friture-bin should contain AppxManifest.xml
+4. in that folder, run: Add-AppxPackage -Register .\AppxManifest.xml
 5. app should start from Windows Start menu
   - to deploy again, increase the version
 6. from the parent folder, run:
-PS C:\...\friture> MakeAppx pack /v /d .\friture-bin /p friture.appx
-7. friture.appx file can be uploaded in a new submission to the Windows Partern Center
+PS C:\...\friture> MakeAppx pack /v /d .\friture-bin /p friture.msix
+7. friture.msix can be uploaded in a new submission to the Microsoft Partner Center
+   (the Store signs the package on ingestion; this CI build produces an
+   unsigned MSIX used for packaging validation only).
 
 References:
 https://docs.microsoft.com/en-us/windows/msix/packaging-tool/create-app-package
@@ -25,7 +27,7 @@ https://docs.microsoft.com/en-us/windows/msix/package/create-app-package-with-ma
         Name="53504SilentGain.Friture"
         Version="0.0.0.0"
         Publisher="CN=74EE87F8-B2A0-400A-A66A-377F7F4E3BBE"
-        ProcessorArchitecture="x86" />
+        ProcessorArchitecture="amd64" />
     <Properties>
         <DisplayName>Friture</DisplayName>
         <PublisherDisplayName>Silent Gain</PublisherDisplayName>
@@ -37,7 +39,7 @@ https://docs.microsoft.com/en-us/windows/msix/package/create-app-package-with-ma
         <Resource Language="en-us" />
     </Resources>
     <Dependencies>
-        <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.14393.0" MaxVersionTested="10.0.14393.0" />
+        <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
     </Dependencies>
     <Capabilities>
         <rescap:Capability Name="runFullTrust"/>

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -34,6 +34,20 @@ except Exception:
 
 TIMEOUT_SECONDS = 20
 
+
+def _kill_proc(proc):
+    """Kill a launched process, cross-platform.
+
+    On POSIX we started the process in its own session (start_new_session=True)
+    and kill the whole process group so a spawned helper child cannot keep the
+    stdout/stderr pipes open and make communicate() hang. Windows has no
+    process groups, so we just TerminateProcess the leader.
+    """
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    except (AttributeError, ProcessLookupError, PermissionError):
+        proc.kill()
+
 # Substrings that, if found in the log or stderr, mean the bundle is broken
 # (a missing Qt module, shared library, or Python extension). We include the
 # Python traceback header and the app's own unhandled-exception log line so a
@@ -122,13 +136,12 @@ def main():
         rc = proc.returncode
     except subprocess.TimeoutExpired:
         timed_out = True
-        # kill the entire process group, not just the leader
-        try:
-            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-        except (ProcessLookupError, PermissionError):
-            proc.kill()
+        _kill_proc(proc)
         stdout, stderr = proc.communicate()
         rc = proc.returncode
+    except KeyboardInterrupt:
+        _kill_proc(proc)
+        raise
 
     elapsed = time.time() - started
 


### PR DESCRIPTION
Build a msix package instead of appx: msix is a more modern, more generic packaging solution. Both can be published to the Microsoft store similarly.

Also add a headless smoke test like we did for AppImage in https://github.com/tlecomte/friture/pull/450